### PR TITLE
fix: split mgs_nids when setting the info

### DIFF
--- a/charms/lustre-server-proxy/src/charm.py
+++ b/charms/lustre-server-proxy/src/charm.py
@@ -32,7 +32,7 @@ class LustreServerProxyCharm(ops.CharmBase):
             self.unit.status = ops.BlockedStatus("No configured fs-name")
             return
 
-        self._filesystem.set_info(LustreInfo(mgs_ids=mgs_nids, fs_name=fs_name))
+        self._filesystem.set_info(LustreInfo(mgs_ids=mgs_nids.split(), fs_name=fs_name))
 
         self.unit.status = ops.ActiveStatus()
 

--- a/charms/lustre-server-proxy/tests/unit/test_charm.py
+++ b/charms/lustre-server-proxy/tests/unit/test_charm.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
-
 """Test base charm events such as Install, ConfigChanged, etc."""
 
 from charm import LustreServerProxyCharm
 from ops import testing
+
+from charms.filesystem_client.v0.filesystem_info import LustreInfo
 
 
 def test_config_none():
@@ -34,9 +35,23 @@ def test_config_no_mgs_ids():
 
 def test_config_full():
     """Test config-changed handler with full config parameters."""
-    context = testing.Context(LustreServerProxyCharm)
-    state = testing.State(
-        config={"mgs-nids": "demo-mgs1@tcp1 demo-mgs2@tcp1", "fs-name": "lustre"}
+    rel = testing.PeerRelation(
+        endpoint="server-peers",
     )
-    out = context.run(context.on.config_changed(), state)
+    state = testing.State(
+        config={"mgs-nids": "demo-mgs1@tcp1 demo-mgs2@tcp1", "fs-name": "lustre"},
+        relations={rel},
+        leader=True,
+    )
+    context = testing.Context(LustreServerProxyCharm)
+
+    with context(context.on.config_changed(), state) as manager:
+        out = manager.run()
+        info = LustreInfo.from_uri(
+            out.get_relation(rel.id).local_app_data["endpoint"], manager.charm.model
+        )
+
     assert out.unit_status == testing.ActiveStatus()
+
+    assert info.fs_name == "lustre"
+    assert info.mgs_ids == ["demo-mgs1@tcp1", "demo-mgs2@tcp1"]

--- a/charms/nfs-server-proxy/tests/unit/test_charm.py
+++ b/charms/nfs-server-proxy/tests/unit/test_charm.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
-# Copyright 2023 Canonical Ltd.
+# Copyright 2023-2025 Canonical Ltd.
 # See LICENSE file for licensing details.
-
 """Test base charm events such as Install, ConfigChanged, etc."""
 
 from charm import NFSServerProxyCharm
 from ops import testing
+
+from charms.filesystem_client.v0.filesystem_info import NfsInfo
 
 
 def test_config_no_hostname():
@@ -33,7 +34,23 @@ def test_config_no_port():
 
 def test_config_full():
     """Test config-changed handler with full config parameters."""
+    rel = testing.PeerRelation(
+        endpoint="server-peers",
+    )
+    state = testing.State(
+        config={"hostname": "127.0.0.1", "path": "/srv", "port": 1234},
+        relations={rel},
+        leader=True,
+    )
     context = testing.Context(NFSServerProxyCharm)
-    state = testing.State(config={"hostname": "127.0.0.1", "path": "/srv", "port": 1234})
-    out = context.run(context.on.config_changed(), state)
+
+    with context(context.on.config_changed(), state) as manager:
+        out = manager.run()
+        info = NfsInfo.from_uri(
+            out.get_relation(rel.id).local_app_data["endpoint"], manager.charm.model
+        )
+
     assert out.unit_status == testing.ActiveStatus()
+    assert info.hostname == "127.0.0.1"
+    assert info.port == 1234
+    assert info.path == "/srv"


### PR DESCRIPTION
Whoops, a bug went through the cracks. This should fix setting the correct info on the server proxy.
This also improves the unit tests to be a bit more strict on the relation data, which should help catch bugs like this.