### PR TITLE
fix: set fstype=nfs4 instead of setting the NFS version

### DIFF
--- a/charms/filesystem-client/src/utils/manager.py
+++ b/charms/filesystem-client/src/utils/manager.py
@@ -207,13 +207,7 @@ def _get_endpoint_and_opts(info: FilesystemInfo) -> tuple[str, list[str]]:
                 pass
 
             endpoint = f"{hostname}:{path}"
-            options = [
-                "fstype=nfs",
-                # NFS mount client should automatically fallback to v4.1, v3 or v2 to accommodate the server's
-                # supported version.
-                "nfsvers=4",
-                "minorversion=2",
-            ]
+            options = ["fstype=nfs4"]
             if port:
                 options.append(f"port={port}")
         case CephfsInfo(


### PR DESCRIPTION
Setting the specific version of NFS to 4.2 was too aggressive of a solution, and the client was only trying the specific version 4.2 instead of downgrading to a supported version.

This sets the `fstype` to `nfs4` instead, which does fallback correctly.