### PR TITLE
chore: bump juju terraform provider version

### DIFF
--- a/charms/cephfs-server-proxy/terraform/versions.tf
+++ b/charms/cephfs-server-proxy/terraform/versions.tf
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.14.0"
+      version = ">= 0.19.0"
     }
   }
 }

--- a/charms/filesystem-client/terraform/main.tf
+++ b/charms/filesystem-client/terraform/main.tf
@@ -24,5 +24,4 @@ resource "juju_application" "filesystem-client" {
   }
 
   config      = var.config
-  units       = 0
 }

--- a/charms/filesystem-client/terraform/versions.tf
+++ b/charms/filesystem-client/terraform/versions.tf
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.14.0"
+      version = ">= 0.19.0"
     }
   }
 }

--- a/charms/lustre-server-proxy/terraform/versions.tf
+++ b/charms/lustre-server-proxy/terraform/versions.tf
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.14.0"
+      version = ">= 0.19.0"
     }
   }
 }

--- a/charms/nfs-server-proxy/terraform/versions.tf
+++ b/charms/nfs-server-proxy/terraform/versions.tf
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.14.0"
+      version = ">= 0.19.0"
     }
   }
 }


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have insured that lint, typecheck, and unit tests complete successfully.

## Summary of changes

Bumps the Juju Terraform provider to 0.19.0, which comes with a change that obviates the need for the `units` parameter on subordinate charms.

## Docs

* [x] I confirm that this pull request requires no changes or additions to documentation.

Just an internal change.

