### PR TITLE
feat: migrate charms to use `charmed-hpc-libs`

### DIFF
--- a/charms/filesystem-client/pyproject.toml
+++ b/charms/filesystem-client/pyproject.toml
@@ -2,6 +2,6 @@
 name = "filesystem-client"
 version = "0.0"
 requires-python = "==3.12.*"
-dependencies = ["ops", "charmlibs-apt", "charmlibs-systemd"]
+dependencies = ["ops", "charmlibs-apt", "charmed-hpc-libs[ops]"]
 
 [tool.repository]

--- a/charms/filesystem-client/src/charm.py
+++ b/charms/filesystem-client/src/charm.py
@@ -8,19 +8,12 @@ import logging
 from typing import cast
 
 import ops
+from charmed_hpc_libs.ops import StopCharm, refresh
 from charms.filesystem_client.v0.filesystem_info import FilesystemRequires
 from charms.filesystem_client.v0.mount_info import MountInfo, MountProvides
 from utils.manager import MountsManager
 
 _logger = logging.getLogger(__name__)
-
-
-class StopCharmError(Exception):
-    """Exception raised when a method needs to finish the execution of the charm code."""
-
-    def __init__(self, status: ops.StatusBase, app: bool = False) -> None:
-        self.status = status
-        self.app = app
 
 
 # Trying to use a delta charm (one method per event) proved to be a bit unwieldy, since
@@ -52,55 +45,47 @@ class FilesystemClientCharm(ops.CharmBase):
         self.framework.observe(self._mount.on.mount_requested, self._handle_event)
         self.framework.observe(self._mount.on.mount_unrequested, self._handle_event)
 
+    @refresh()
     def _handle_event(self, event: ops.EventBase) -> None:
         """Handle a Juju event."""
-        try:
-            self.unit.status = ops.MaintenanceStatus("Updating status")
+        self._mount.set_mount_status(mounted=False)
+        self.unit.status = ops.MaintenanceStatus("Updating status")
 
-            # CephFS is not supported on LXD containers.
-            if not self._mounts_manager.supported():
-                self.unit.status = ops.BlockedStatus("Cannot mount filesystems on LXD containers")
-                return
+        if not self._mounts_manager.supported():
+            raise StopCharm(ops.BlockedStatus("Cannot mount filesystems on LXD containers"))
 
-            self._ensure_installed()
+        self._ensure_installed()
 
-            with self._mounts_manager.mounts() as mounts:
-                config = self._get_config()
-                endpoints = self._filesystem.endpoints
-                if not endpoints:
-                    raise StopCharmError(
-                        ops.BlockedStatus("Waiting for an integration with a filesystem provider"),
-                        app=True,
-                    )
+        with self._mounts_manager.mounts() as mounts:
+            config = self._get_config()
+            endpoints = self._filesystem.endpoints
+            if not endpoints:
+                raise StopCharm(
+                    ops.BlockedStatus("Waiting for an integration with a filesystem provider"),
+                    set_app_status=True,
+                )
 
-                # This is limited to 1 relation.
-                endpoint = endpoints[0]
+            # This is limited to 1 relation.
+            endpoint = endpoints[0]
 
-                if self.unit.is_leader():
-                    self.app.status = ops.ActiveStatus(
-                        f"Integrated with `{endpoint.info.filesystem_type()}` provider"
-                    )
+            if self.unit.is_leader():
+                self.app.status = ops.ActiveStatus(
+                    f"Integrated with `{endpoint.info.filesystem_type()}` provider"
+                )
 
-                self.unit.status = ops.MaintenanceStatus("Mounting filesystem")
+            self.unit.status = ops.MaintenanceStatus("Mounting filesystem")
 
-                opts = []
+            opts = []
 
-                opts.append("noexec" if config.noexec else "exec")
-                opts.append("nosuid" if config.nosuid else "suid")
-                opts.append("nodev" if config.nodev else "dev")
-                opts.append("ro" if config.read_only else "rw")
-                mounts.add(info=endpoint.info, mountpoint=config.mountpoint, options=opts)
+            opts.append("noexec" if config.noexec else "exec")
+            opts.append("nosuid" if config.nosuid else "suid")
+            opts.append("nodev" if config.nodev else "dev")
+            opts.append("ro" if config.read_only else "rw")
+            mounts.add(info=endpoint.info, mountpoint=config.mountpoint, options=opts)
 
-                self._mount.set_mount_status(mounted=True)
+            self.unit.status = ops.ActiveStatus(f"Mounted filesystem at `{config.mountpoint}`")
 
-                self.unit.status = ops.ActiveStatus(f"Mounted filesystem at `{config.mountpoint}`")
-        except StopCharmError as e:
-            self._mount.set_mount_status(mounted=False)
-            # This was the cleanest way to ensure the inner methods can still return prematurely
-            # when an error occurs.
-            self.unit.status = e.status
-            if self.unit.is_leader() and e.app:
-                self.app.status = e.status
+        self._mount.set_mount_status(mounted=True)
 
     def _ensure_installed(self) -> None:
         """Ensure the required packages are installed into the unit."""
@@ -116,33 +101,33 @@ class FilesystemClientCharm(ops.CharmBase):
         if not mountpoint:
             relation = next(relations, None)
             if not relation:
-                raise StopCharmError(
+                raise StopCharm(
                     ops.BlockedStatus("Missing `mountpoint` config or `mount` integration"),
-                    app=True,
+                    set_app_status=True,
                 )
 
             if next(relations, None):
-                raise StopCharmError(
+                raise StopCharm(
                     ops.BlockedStatus(
                         "Cannot mount using more than one relation at the same time"
                     ),
-                    app=True,
+                    set_app_status=True,
                 )
 
             mount_info = self._mount.mount_info(relation.id)
             if not mount_info:
-                raise StopCharmError(
+                raise StopCharm(
                     ops.WaitingStatus("Waiting for mountpoint from `mount` integration")
                 )
 
             return mount_info
 
         if next(relations, None):
-            raise StopCharmError(
+            raise StopCharm(
                 ops.BlockedStatus(
                     "Cannot mount using both the `mountpoint` config and the `mount` integration"
                 ),
-                app=True,
+                set_app_status=True,
             )
 
         return MountInfo(

--- a/charms/filesystem-client/src/utils/manager.py
+++ b/charms/filesystem-client/src/utils/manager.py
@@ -7,13 +7,14 @@ import contextlib
 import logging
 import os
 import pathlib
-import subprocess
 from collections.abc import Iterator
 from dataclasses import dataclass
 from ipaddress import AddressValueError, IPv6Address
 
 import ops
-from charmlibs import apt, systemd
+from charmed_hpc_libs.errors import SystemdError, UnknownVirtualizationStateError
+from charmed_hpc_libs.ops import is_container, systemctl
+from charmlibs import apt
 from charms.filesystem_client.v0.filesystem_info import (
     CephfsInfo,
     FilesystemInfo,
@@ -150,15 +151,8 @@ class MountsManager:
     def supported(self) -> bool:
         """Check if underlying base supports mounting shares."""
         try:
-            result = subprocess.run(
-                ["systemd-detect-virt"], stdout=subprocess.PIPE, check=True, text=True
-            )
-            if "lxc" in result.stdout:
-                # Cannot mount shares inside LXD containers.
-                return False
-            else:
-                return True
-        except subprocess.CalledProcessError:
+            return not is_container()
+        except UnknownVirtualizationStateError:
             _logger.warning("could not detect execution in virtualized environment")
             return True
 
@@ -193,8 +187,8 @@ class MountsManager:
             for mount in mounts._mounts.keys():
                 pathlib.Path(mount).mkdir(parents=True, exist_ok=True)
             self._autofs_file.write_text(new_autofs)
-            systemd.service_reload("autofs", restart_on_failure=True)
-        except systemd.SystemdError as e:
+            systemctl("reload-or-restart", "autofs", check=True)
+        except SystemdError as e:
             _logger.error("failed to mount filesystems", exc_info=e)
             raise Error("failed to mount filesystems")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dev = [
 
   # Integration
   "jubilant",
-  "pytest",
+  "pytest ~= 9.0",
   "pytest-order ~= 1.1",
   "tenacity ~= 8.2",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires-python = "==3.12.*"
 dependencies = [
     "ops ~= 3.0",
     "charmlibs-apt ~= 1.0",
-    "charmlibs-systemd ~= 1.0"
+    "charmed-hpc-libs[ops] ~= 0.1",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -24,6 +24,22 @@ dependencies = [
 requires-dist = [{ name = "ops" }]
 
 [[package]]
+name = "charmed-hpc-libs"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4a/e1/279750719ae505b969bb604aadd844d05212e5c4ddfef585cfa8e0131e1f/charmed_hpc_libs-0.1.2.tar.gz", hash = "sha256:f86603696d7ca52182073b00d42b6b8d66ea1ce864155aeb6670e6a9481cd415", size = 47026, upload-time = "2026-04-17T14:06:25.893Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/9e/9ceda5fbc3b3459d1687a7756594962fa40df6676bd8252b60109711712b/charmed_hpc_libs-0.1.2-py3-none-any.whl", hash = "sha256:546d01e6b23a0be97393fdd43d5fb72f175d3e36d635629aa3854c436ec488a4", size = 24473, upload-time = "2026-04-17T14:06:26.884Z" },
+]
+
+[package.optional-dependencies]
+ops = [
+    { name = "ops" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+]
+
+[[package]]
 name = "charmlibs-apt"
 version = "1.0.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -33,15 +49,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fd/58/33e87779fdbcf62a3b34e3444d7175c1168b4b2726cc29c98849c09ac086/charmlibs_apt-1.0.0.post0.tar.gz", hash = "sha256:9c2e0b3c1f553ebcaae99c9aad72e15383aec56677a8dd3f6479dc6f084189a6", size = 31942, upload-time = "2025-10-15T02:40:29.521Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dd/92/4db19cd8bc94db51a115f7a2e3c46d96b991ca7ebe27207beac9a6570bc6/charmlibs_apt-1.0.0.post0-py3-none-any.whl", hash = "sha256:958e84719eb1feff539f058dc6c7af648c53c88b9ebe7c6157ec8d2bdf5fbfc6", size = 19287, upload-time = "2025-10-15T02:40:27.756Z" },
-]
-
-[[package]]
-name = "charmlibs-systemd"
-version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/35/3d/234da07da24ec5ae37184e6b05eeccb994f4e786829cd8efe15b3dff45ee/charmlibs_systemd-1.0.0.tar.gz", hash = "sha256:947e93b076e105509b190020ec16de051e9015c1eb12904192fb39489e0e1caa", size = 15746, upload-time = "2025-11-26T21:32:08.399Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/2e/5fe4d18e52df0fedbf4c4a9e1f6fe0f93f11611a670afb26f808cfd44208/charmlibs_systemd-1.0.0-py3-none-any.whl", hash = "sha256:37d4022e28f70f7a2a54fbff7c5694d25dc62dbb8680feffabde8c324a432199", size = 4904, upload-time = "2025-11-26T21:32:07.103Z" },
 ]
 
 [[package]]
@@ -91,15 +98,15 @@ name = "filesystem-client"
 version = "0.0"
 source = { virtual = "charms/filesystem-client" }
 dependencies = [
+    { name = "charmed-hpc-libs", extra = ["ops"] },
     { name = "charmlibs-apt" },
-    { name = "charmlibs-systemd" },
     { name = "ops" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "charmed-hpc-libs", extras = ["ops"] },
     { name = "charmlibs-apt" },
-    { name = "charmlibs-systemd" },
     { name = "ops" },
 ]
 
@@ -108,8 +115,8 @@ name = "filesystems"
 version = "0.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "charmed-hpc-libs", extra = ["ops"] },
     { name = "charmlibs-apt" },
-    { name = "charmlibs-systemd" },
     { name = "ops" },
 ]
 
@@ -128,8 +135,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "charmed-hpc-libs", extras = ["ops"], specifier = "~=0.1" },
     { name = "charmlibs-apt", specifier = "~=1.0" },
-    { name = "charmlibs-systemd", specifier = "~=1.0" },
     { name = "codespell", marker = "extra == 'dev'" },
     { name = "coverage", extras = ["toml"], marker = "extra == 'dev'" },
     { name = "jubilant", marker = "extra == 'dev'" },
@@ -319,6 +326,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1d/66/02ae17461b14a52ce5a29ae2900156b9110d1de34721ccc16ccd79419876/pytest_order-1.3.0.tar.gz", hash = "sha256:51608fec3d3ee9c0adaea94daa124a5c4c1d2bb99b00269f098f414307f23dde", size = 47544, upload-time = "2024-08-22T12:29:54.512Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1b/73/59b038d1aafca89f8e9936eaa8ffa6bb6138d00459d13a32ce070be4f280/pytest_order-1.3.0-py3-none-any.whl", hash = "sha256:2cd562a21380345dd8d5774aa5fd38b7849b6ee7397ca5f6999bbe6e89f07f6e", size = 14609, upload-time = "2024-08-22T12:29:53.156Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/b0/4bc07ccd3572a2f9df7e6782f52b0c6c90dcbb803ac4a167702d7d0dfe1e/python_dotenv-1.1.1.tar.gz", hash = "sha256:a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab", size = 41978, upload-time = "2025-06-24T04:21:07.341Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/ed/539768cf28c661b5b068d66d96a2f155c4971a5d55684a514c1a0e0dec2f/python_dotenv-1.1.1-py3-none-any.whl", hash = "sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc", size = 20556, upload-time = "2025-06-24T04:21:06.073Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -136,7 +136,7 @@ requires-dist = [
     { name = "ops", specifier = "~=3.0" },
     { name = "ops", extras = ["testing"], marker = "extra == 'dev'" },
     { name = "pyright", marker = "extra == 'dev'" },
-    { name = "pytest", marker = "extra == 'dev'" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = "~=9.0" },
     { name = "pytest-order", marker = "extra == 'dev'", specifier = "~=1.1" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "tenacity", marker = "extra == 'dev'", specifier = "~=8.2" },
@@ -272,6 +272,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
 name = "pyright"
 version = "1.1.408"
 source = { registry = "https://pypi.org/simple" }
@@ -286,17 +295,18 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "7.4.4"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
+    { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/80/1f/9d8e98e4133ffb16c90f3b405c43e38d3abb715bb5d7a63a5a684f7e46a3/pytest-7.4.4.tar.gz", hash = "sha256:2cf0005922c6ace4a3e2ec8b4080eb0d9753fdc93107415332f50ce9e7994280", size = 1357116, upload-time = "2023-12-31T12:00:18.035Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/ff/f6e8b8f39e08547faece4bd80f89d5a8de68a38b2d179cc1c4490ffa3286/pytest-7.4.4-py3-none-any.whl", hash = "sha256:b090cdf5ed60bf4c45261be03239c2c1c22df034fbffe691abe93cd80cea01d8", size = 325287, upload-time = "2023-12-31T12:00:13.963Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

## Summary of changes

Migrates all our charms to use `charmed-hpc-libs` where required, which is only valid for the `filesystem-client`.

## Docs

* [x] I confirm that this pull request requires no changes or additions to documentation.

This is only an internal change that should not be visible to users.
