### PR TITLE
fix: correctly update mount relation on hook exception

### DIFF
--- a/charms/filesystem-client/src/charm.py
+++ b/charms/filesystem-client/src/charm.py
@@ -51,41 +51,48 @@ class FilesystemClientCharm(ops.CharmBase):
         self._mount.set_mount_status(mounted=False)
         self.unit.status = ops.MaintenanceStatus("Updating status")
 
-        if not self._mounts_manager.supported():
-            raise StopCharm(ops.BlockedStatus("Cannot mount filesystems on LXD containers"))
+        try:
+            if not self._mounts_manager.supported():
+                raise StopCharm(ops.BlockedStatus("Cannot mount filesystems on LXD containers"))
 
-        self._ensure_installed()
+            self._ensure_installed()
 
-        with self._mounts_manager.mounts() as mounts:
-            config = self._get_config()
-            endpoints = self._filesystem.endpoints
-            if not endpoints:
-                raise StopCharm(
-                    ops.BlockedStatus("Waiting for an integration with a filesystem provider"),
-                    set_app_status=True,
-                )
+            with self._mounts_manager.mounts() as mounts:
+                config = self._get_config()
+                endpoints = self._filesystem.endpoints
+                if not endpoints:
+                    raise StopCharm(
+                        ops.BlockedStatus("Waiting for an integration with a filesystem provider"),
+                        set_app_status=True,
+                    )
 
-            # This is limited to 1 relation.
-            endpoint = endpoints[0]
+                # This is limited to 1 relation.
+                endpoint = endpoints[0]
 
-            if self.unit.is_leader():
-                self.app.status = ops.ActiveStatus(
-                    f"Integrated with `{endpoint.info.filesystem_type()}` provider"
-                )
+                if self.unit.is_leader():
+                    self.app.status = ops.ActiveStatus(
+                        f"Integrated with `{endpoint.info.filesystem_type()}` provider"
+                    )
 
-            self.unit.status = ops.MaintenanceStatus("Mounting filesystem")
+                self.unit.status = ops.MaintenanceStatus("Mounting filesystem")
 
-            opts = []
+                opts = []
+                opts.append("noexec" if config.noexec else "exec")
+                opts.append("nosuid" if config.nosuid else "suid")
+                opts.append("nodev" if config.nodev else "dev")
+                opts.append("ro" if config.read_only else "rw")
+                mounts.add(info=endpoint.info, mountpoint=config.mountpoint, options=opts)
 
-            opts.append("noexec" if config.noexec else "exec")
-            opts.append("nosuid" if config.nosuid else "suid")
-            opts.append("nodev" if config.nodev else "dev")
-            opts.append("ro" if config.read_only else "rw")
-            mounts.add(info=endpoint.info, mountpoint=config.mountpoint, options=opts)
+                self.unit.status = ops.ActiveStatus(f"Mounted filesystem at `{config.mountpoint}`")
 
-            self.unit.status = ops.ActiveStatus(f"Mounted filesystem at `{config.mountpoint}`")
-
-        self._mount.set_mount_status(mounted=True)
+            self._mount.set_mount_status(mounted=True)
+        except StopCharm:
+            raise
+        except Exception:
+            _logger.error("unexpected error while handling event", exc_info=True)
+            raise StopCharm(
+                ops.BlockedStatus("Failed to mount filesystems. See `juju debug-log` for details")
+            )
 
     def _ensure_installed(self) -> None:
         """Ensure the required packages are installed into the unit."""

--- a/charms/filesystem-client/tests/unit/test_charm.py
+++ b/charms/filesystem-client/tests/unit/test_charm.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# Copyright 2024-2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Unit tests for FilesystemClientCharm."""
+
+import json
+from dataclasses import asdict
+from unittest.mock import MagicMock, patch
+
+import pytest
+from charm import FilesystemClientCharm
+from charms.filesystem_client.v0.mount_info import MountInfo
+from ops import testing
+from utils.manager import Error
+
+
+@pytest.fixture(scope="function")
+def ctx() -> testing.Context[FilesystemClientCharm]:
+    """Mock `FilesystemClientCharm` context."""
+    return testing.Context(FilesystemClientCharm)
+
+
+@pytest.fixture(scope="function")
+def mock_mounts_manager() -> MagicMock:
+    """Mock `charm.MountsManager`."""
+    with patch("charm.MountsManager") as manager_cls:
+        mock_manager = MagicMock()
+        manager_cls.return_value = mock_manager
+        yield mock_manager
+
+
+@pytest.mark.parametrize(
+    "installed", (pytest.param(True, id="installed"), pytest.param(False, id="not installed"))
+)
+def test_manager_mounted_false_if_exc(
+    ctx: testing.Context, installed: bool, mock_mounts_manager: MagicMock
+) -> None:
+    """mounted=false is written in the case of a raised exception."""
+    mount_rel = testing.SubordinateRelation(endpoint="mount")
+    state_in = testing.State(relations={mount_rel})
+
+    mock_mounts_manager.supported.return_value = True
+    mock_mounts_manager.installed = installed
+    mock_mounts_manager.install.side_effect = Error("apt failed")
+    mock_mounts_manager.mounts.side_effect = RuntimeError("unexpected")
+
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+
+    assert state_out.get_relation(mount_rel.id).local_unit_data["mounted"] == "false"
+    assert state_out.unit_status == testing.BlockedStatus(
+        "Failed to mount filesystems. See `juju debug-log` for details"
+    )
+
+
+def test_successful_mount_sets_mounted_true(
+    ctx: testing.Context, mock_mounts_manager: MagicMock
+) -> None:
+    """mounted=true is written and ActiveStatus is set after a successful mount."""
+    mount_rel = testing.SubordinateRelation(
+        endpoint="mount",
+        remote_app_data={
+            k: json.dumps(v) for k, v in asdict(MountInfo(mountpoint="/mnt/nfs")).items()
+        },
+    )
+    fs_rel = testing.Relation(
+        endpoint="filesystem",
+        remote_app_data={"endpoint": "nfs://(192.168.1.1)/srv"},
+    )
+    state_in = testing.State(
+        leader=True,
+        relations={mount_rel, fs_rel},
+    )
+
+    mock_mounts_manager.supported.return_value = True
+    mock_mounts_manager.installed = True
+    mock_mounts_manager.mounts = MagicMock()
+
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+
+    assert state_out.get_relation(mount_rel.id).local_unit_data["mounted"] == "true"
+    assert state_out.unit_status == testing.ActiveStatus("Mounted filesystem at `/mnt/nfs`")


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

## Summary of changes

Fixes an issue discovered by @dsloanm where applications related to the filesystem-client using the `mount` relation wouldn't be notified of mount errors if the event handler raised an uncaught exception.

## Docs

* [x] I confirm that this pull request requires no changes or additions to documentation.

This is only an internal bug fix.
