### PR TITLE
chore: migrate repo to the canonical org

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-** @charmed-hpc/python-reviewers
+** @canonical/hpc-code-reviewers

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+# Pre-submission checklist
+
+ * [ ] I read and followed the CONTRIBUTING guidelines.
+ * [ ] I have ensured that lint, typecheck, and unit tests complete successfully.
+
+[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)
+
+## Summary of changes
+
+[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)
+
+
+
+#### Related Issues, PRs, and Discussions
+
+[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)
+
+
+
+## Docs
+
+* [ ] I have created a pull request to add or update relevant documentation in [charmed-hpc/docs](https://github.com/charmed-hpc/docs) or another documentation location.
+
+[//]: # (If documentation has been updated or added in a location other than charmed-hpc/docs, please note the location here.)
+
+Or:
+
+* [ ] I confirm that this pull request requires no changes or additions to documentation.
+
+[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,12 +7,10 @@ Before you start working on your contribution, please familiarize yourself with 
 HPC project's contributing guide]. After you've gone through the main contributing guide,
 you can use this guide for specific information on contributing to the `filesystem-charms` repository.
 
-Have any questions? Feel free to ask them in the [Ubuntu High-Performance Computing Matrix chat]
-or on [GitHub Discussions].
+Have any questions? Feel free to ask them in the [Ubuntu High-Performance Computing Matrix chat].
 
-[Charmed HPC project's contributing guide]: https://github.com/charmed-hpc/docs/blob/main/CONTRIBUTING.md
+[Charmed HPC project's contributing guide]: https://github.com/canonical/charmed-hpc-docs/blob/main/CONTRIBUTING.md
 [Ubuntu High-Performance Computing Matrix chat]: https://matrix.to/#/#hpc:ubuntu.com
-[GitHub Discussions]: https://github.com/orgs/charmed-hpc/discussions/categories/support
 
 ## Hacking on `filesystem-charms`
 
@@ -118,4 +116,3 @@ and you make changes to that file in 2025, update the copyright year in the file
 ```text
 Copyright 2023-2025 Canonical Ltd.
 ```
-

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Filesystem charms
 
-[![CI](https://github.com/charmed-hpc/filesystem-charms/actions/workflows/ci.yaml/badge.svg)](https://github.com/charmed-hpc/filesystem-charms/actions/workflows/ci.yaml/badge.svg)
-[![Publish](https://github.com/charmed-hpc/filesystem-charms/actions/workflows/publish.yaml/badge.svg)](https://github.com/charmed-hpc/filesystem-charms/actions/workflows/publish.yaml/badge.svg)
+[![CI](https://github.com/canonical/filesystem-charms/actions/workflows/ci.yaml/badge.svg)](https://github.com/canonical/filesystem-charms/actions/workflows/ci.yaml/badge.svg)
+[![Publish](https://github.com/canonical/filesystem-charms/actions/workflows/publish.yaml/badge.svg)](https://github.com/canonical/filesystem-charms/actions/workflows/publish.yaml/badge.svg)
 [![Matrix](https://img.shields.io/matrix/ubuntu-hpc%3Amatrix.org?logo=matrix&label=ubuntu-hpc)](https://matrix.to/#/#ubuntu-hpc:matrix.org)
 
 [Juju](https://juju.is) charms to manage shared filesystems.
@@ -149,7 +149,7 @@ constructive feedback. Interested in being involved with the development of the 
 - [Join our online chat](https://matrix.to/#/#ubuntu-hpc:matrix.org)
 - [Contributing guidelines](./CONTRIBUTING.md)
 - [Code of conduct](https://ubuntu.com/community/ethos/code-of-conduct)
-- [File a bug report](https://github.com/charmed-hpc/filesystem-charms/issues)
+- [File a bug report](https://github.com/canonical/filesystem-charms/issues)
 - [Juju SDK docs](https://juju.is/docs/sdk)
 
 ## 📋 License

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,7 +15,7 @@ The preferred way to report a security issue is through [GitHub Security Advisor
 [Privately reporting a security vulnerability][how-to-sec-vuln] for instructions on how to report a security vulnerability
 using GitHub's security advisory feature.
 
-[gsa]: https://github.com/charmed-hpc/filesystem-charms/security/advisories/new
+[gsa]: https://github.com/canonical/filesystem-charms/security/advisories/new
 [how-to-sec-vuln]: https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability
 
 You may also send email to [security@ubuntu.com](mailto:security@ubuntu.com). Email may optionally be encrypted to OpenPGP

--- a/charms/cephfs-server-proxy/charmcraft.yaml
+++ b/charms/cephfs-server-proxy/charmcraft.yaml
@@ -10,10 +10,10 @@ description: |
 
   Enable CephFS Client charms to mount non-charmed Ceph shares.
 links:
-  source: 
-  - https://github.com/charmed-hpc/filesystem-charms
-  issues: 
-  - https://github.com/charmed-hpc/filesystem-charms/issues
+  source:
+  - https://github.com/canonical/filesystem-charms
+  issues:
+  - https://github.com/canonical/filesystem-charms/issues
 
 base: ubuntu@24.04
 platforms:

--- a/charms/lustre-server-proxy/charmcraft.yaml
+++ b/charms/lustre-server-proxy/charmcraft.yaml
@@ -10,10 +10,10 @@ description: |
 
   Enable Lustre Client charms to mount non-charmed Lustre shares.
 links:
-  source: 
-  - https://github.com/charmed-hpc/filesystem-charms
-  issues: 
-  - https://github.com/charmed-hpc/filesystem-charms/issues
+  source:
+  - https://github.com/canonical/filesystem-charms
+  issues:
+  - https://github.com/canonical/filesystem-charms/issues
 
 base: ubuntu@24.04
 platforms:

--- a/charms/nfs-server-proxy/charmcraft.yaml
+++ b/charms/nfs-server-proxy/charmcraft.yaml
@@ -10,10 +10,10 @@ description: |
 
   Enable NFS Client charms to mount non-charmed NFS shares.
 links:
-  source: 
-  - https://github.com/charmed-hpc/filesystem-charms
-  issues: 
-  - https://github.com/charmed-hpc/filesystem-charms/issues
+  source:
+  - https://github.com/canonical/filesystem-charms
+  issues:
+  - https://github.com/canonical/filesystem-charms/issues
 
 base: ubuntu@24.04
 platforms:


### PR DESCRIPTION
Migrate all our references to the charmed-hpc org to the canonical org equivalent.