### PR TITLE
feat: implement `lustre-ops` internal package and IB support

### DIFF
--- a/charms/filesystem-client/charmcraft.yaml
+++ b/charms/filesystem-client/charmcraft.yaml
@@ -72,3 +72,19 @@ config:
       default: false
       description: Enable support for mounting Lustre filesystems.
       type: boolean
+    lnet-networks:
+      type: string
+      default: ""
+      description: |
+        LNet network configuration. Syntax:
+
+        "tcp=eth0; o2ib0=ib0,ib1"
+
+        Each network is "<name>=<iface>[,<iface>...]" where <name> is the full LNet network name
+        (examples: tcp0, o2ib1). Multiple interfaces form a multi-rail network.
+
+        Leave empty to auto-detect a setup of a "tcp" network on the default route interface and an
+        "o2ib" network on all RDMA devices.
+
+        This configuration is used only when the charm is first deployed. Changes made to this value
+        after deployment will not be applied.

--- a/charms/filesystem-client/pyproject.toml
+++ b/charms/filesystem-client/pyproject.toml
@@ -4,7 +4,4 @@ version = "0.0"
 requires-python = "==3.14.*"
 dependencies = ["ops", "charmlibs-apt", "charmed-hpc-libs[ops]", "lustre-ops"]
 
-[tool.uv.sources]
-lustre-ops = { workspace = true }
-
 [tool.repository]

--- a/charms/filesystem-client/pyproject.toml
+++ b/charms/filesystem-client/pyproject.toml
@@ -2,6 +2,9 @@
 name = "filesystem-client"
 version = "0.0"
 requires-python = "==3.14.*"
-dependencies = ["ops", "charmlibs-apt", "charmed-hpc-libs[ops]"]
+dependencies = ["ops", "charmlibs-apt", "charmed-hpc-libs[ops]", "lustre-ops"]
+
+[tool.uv.sources]
+lustre-ops = { workspace = true }
 
 [tool.repository]

--- a/charms/filesystem-client/src/charm.py
+++ b/charms/filesystem-client/src/charm.py
@@ -51,6 +51,7 @@ class FilesystemClientCharm(ops.CharmBase):
         self._mount.set_mount_status(mounted=False)
         self.unit.status = ops.MaintenanceStatus("Updating status")
         self._mounts_manager.enable_lustre = cast(bool, self.config.get("enable-lustre"))
+        self._mounts_manager.lnet_networks_spec = cast(str, self.config.get("lnet-networks"))
 
         try:
             if not self._mounts_manager.supported():

--- a/charms/filesystem-client/src/charm.py
+++ b/charms/filesystem-client/src/charm.py
@@ -11,6 +11,7 @@ import ops
 from charmed_hpc_libs.ops import StopCharm, refresh
 from charms.filesystem_client.v0.filesystem_info import FilesystemRequires
 from charms.filesystem_client.v0.mount_info import MountInfo, MountProvides
+from lustre_ops import lnet
 from utils.manager import MountsManager
 
 _logger = logging.getLogger(__name__)
@@ -51,11 +52,14 @@ class FilesystemClientCharm(ops.CharmBase):
         self._mount.set_mount_status(mounted=False)
         self.unit.status = ops.MaintenanceStatus("Updating status")
         self._mounts_manager.enable_lustre = cast(bool, self.config.get("enable-lustre"))
-        self._mounts_manager.lnet_networks_spec = cast(str, self.config.get("lnet-networks"))
+        lnet_networks_spec = cast(str, self.config.get("lnet-networks"))
 
         try:
             if not self._mounts_manager.supported():
                 raise StopCharm(ops.BlockedStatus("Cannot mount filesystems on LXD containers"))
+
+            if self._mounts_manager.enable_lustre:
+                self._mounts_manager.lnet_networks = lnet.parse_network_config(lnet_networks_spec)
 
             self._ensure_setup()
 

--- a/charms/filesystem-client/src/utils/constants.py
+++ b/charms/filesystem-client/src/utils/constants.py
@@ -1,46 +1,7 @@
 """Constants used within the charm."""
 
-from pathlib import Path
-
-LUSTRE_REPOSITORY_KEY = """-----BEGIN PGP PUBLIC KEY BLOCK-----
-Comment: Hostname:
-Version: Hockeypuck 2.2
-
-xsFNBGTuZb8BEACtJ1CnZe6/hv84DceHv+a54y3Pqq0gqED0xhTKnbj/E2ByJpmT
-NlDNkpeITwPAAN1e3824Me76Qn31RkogTMoPJ2o2XfG253RXd67MPxYhfKTJcnM3
-CEkmeI4u2Lynh3O6RQ08nAFS2AGTeFVFH2GPNWrfOsGZW03Jas85TZ0k7LXVHiBs
-W6qonbsFJhshvwC3SryG4XYT+z/+35x5fus4rPtMrrEOD65hij7EtQNaE8owuAju
-Kcd0m2b+crMXNcllWFWmYMV0VjksQvYD7jwGrWeKs+EeHgU8ZuqaIP4pYHvoQjag
-umqnH9Qsaq5NAXiuAIAGDIIV4RdAfQIR4opGaVgIFJdvoSwYe3oh2JlrLPBlyxyY
-dayDifd3X8jxq6/oAuyH1h5K/QLs46jLSR8fUbG98SCHlRmvozTuWGk+e07ALtGe
-sGv78ToHKwoM2buXaTTHMwYwu7Rx8LZ4bZPHdersN1VW/m9yn1n5hMzwbFKy2s6/
-D4Q2ZBsqlN+5aW2q0IUmO+m0GhcdaDv8U7RVto1cWWPr50HhiCi7Yvei1qZiD9jq
-57oYZVqTUNCTPxi6NeTOdEc+YqNynWNArx4PHh38LT0bqKtlZCGHNfoAJLPVYhbB
-b2AHj9edYtHU9AAFSIy+HstET6P0UDxy02IeyE2yxoUBqdlXyv6FL44E+wARAQAB
-zRxMYXVuY2hwYWQgUFBBIGZvciBVYnVudHUgSFBDwsGOBBMBCgA4FiEErocSHcPk
-oLD4H/Aj9tDF1ca+s3sFAmTuZb8CGwMFCwkIBwIGFQoJCAsCBBYCAwECHgECF4AA
-CgkQ9tDF1ca+s3sz3w//RNawsgydrutcbKf0yphDhzWS53wgfrs2KF1KgB0u/H+u
-6Kn2C6jrVM0vuY4NKpbEPCduOj21pTCepL6PoCLv++tICOLVok5wY7Zn3WQFq0js
-Iy1wO5t3kA1cTD/05v/qQVBGZ2j4DsJo33iMcQS5AjHvSr0nu7XSvDDEE3cQE55D
-87vL7lgGjuTOikPh5FpCoS1gpemBfwm2Lbm4P8vGOA4/witRjGgfC1fv1idUnZLM
-TbGrDlhVie8pX2kgB6yTYbJ3P3kpC1ZPpXSRWO/cQ8xoYpLBTXOOtqwZZUnxyzHh
-gM+hv42vPTOnCo+apD97/VArsp59pDqEVoAtMTk72fdBqR+BB77g2hBkKESgQIEq
-EiE1/TOISioMkE0AuUdaJ2ebyQXugSHHuBaqbEC47v8t5DVN5Qr9OriuzCuSDNFn
-6SBHpahN9ZNi9w0A/Yh1+lFfpkVw2t04Q2LNuupqOpW+h3/62AeUqjUIAIrmfeML
-IDRE2VdquYdIXKuhNvfpJYGdyvx/wAbiAeBWg0uPSepwTfTG59VPQmj0FtalkMnN
-ya2212K5q68O5eXOfCnGeMvqIXxqzpdukxSZnLkgk40uFJnJVESd/CxHquqHPUDE
-fy6i2AnB3kUI27D4HY2YSlXLSRbjiSxTfVwNCzDsIh7Czefsm6ITK2+cVWs0hNQ=
-=cs1s
------END PGP PUBLIC KEY BLOCK-----
-"""
-LUSTRE_REPOSITORY_URI = "https://ppa.launchpadcontent.net/ubuntu-hpc/lustre-2.17/ubuntu/"
-LUSTRE_LNET_CONF = Path("/etc/lnet.conf")
-
 BASE_PACKAGES = ("ceph-common", "nfs-common", "autofs")
 LUSTRE_PACKAGES = (
     "lustre-client-utils",
     "lustre-client-modules-dkms",
 )
-
-IP_EXECUTABLE = "/usr/sbin/ip"
-LNETCTL_EXECUTABLE = "/usr/sbin/lnetctl"

--- a/charms/filesystem-client/src/utils/manager.py
+++ b/charms/filesystem-client/src/utils/manager.py
@@ -4,12 +4,9 @@
 """Manage machine mounts and dependencies."""
 
 import contextlib
-import json
 import logging
 import os
 import pathlib
-import platform
-import subprocess
 from collections.abc import Iterator
 from dataclasses import dataclass
 from ipaddress import AddressValueError, IPv6Address
@@ -24,15 +21,13 @@ from charms.filesystem_client.v0.filesystem_info import (
     LustreInfo,
     NfsInfo,
 )
+from lustre_ops import lnet, ppa
+from lustre_ops.constants import LUSTRE_LNET_CONF
+from lustre_ops.errors import LNetError, RepositoryError
 
 from utils.constants import (
     BASE_PACKAGES,
-    IP_EXECUTABLE,
-    LNETCTL_EXECUTABLE,
-    LUSTRE_LNET_CONF,
     LUSTRE_PACKAGES,
-    LUSTRE_REPOSITORY_KEY,
-    LUSTRE_REPOSITORY_URI,
 )
 
 _logger = logging.getLogger(__name__)
@@ -121,6 +116,7 @@ class MountsManager:
         self._master_file = pathlib.Path(f"/etc/auto.master.d/{unit_id}.autofs")
         self._autofs_file = pathlib.Path(f"/etc/auto.{unit_id}")
         self.enable_lustre = False
+        self.lnet_networks_spec = ""
 
     def _packages(self) -> list[apt.DebianPackage]:
         """List of packages required by the client."""
@@ -135,33 +131,11 @@ class MountsManager:
         if self._pkgs and any(pkg.name in LUSTRE_PACKAGES for pkg in self._pkgs):
             return self._pkgs
 
-        repositories = apt.RepositoryMapping()
-
         try:
-            release = platform.freedesktop_os_release()["VERSION_CODENAME"]
-        except KeyError as e:
-            _logger.error(
-                "failed to determine Ubuntu version codename to configure Lustre repository",
-                exc_info=e,
-            )
-            raise Error(str(e))
-
-        try:
-            repo = apt.DebianRepository(
-                enabled=True,
-                repotype="deb",
-                uri=LUSTRE_REPOSITORY_URI,
-                release=release,
-                groups=["main"],
-                filename="lustre-repo",
-            )
-            repo.import_key(LUSTRE_REPOSITORY_KEY)
-            # adding the debian repository should have idempotent semantics.
-            repositories.add(repo)
-            apt.update()
-        except (apt.GPGKeyError, subprocess.CalledProcessError) as e:
-            _logger.error("failed to add %s package repository", LUSTRE_REPOSITORY_URI, exc_info=e)
-            raise Error(str(e))
+            ppa.setup_lustre_repository()
+        except RepositoryError as e:
+            _logger.error("failed to add Lustre package repository", exc_info=e)
+            raise Error(str(e)) from e
 
         self._pkgs = [
             apt.DebianPackage.from_system(pkg) for pkg in BASE_PACKAGES + LUSTRE_PACKAGES
@@ -207,10 +181,12 @@ class MountsManager:
         if not self.enable_lustre:
             return
 
-        # Enable LNet on default network interface if not already enabled.
-        # TODO: Add InfiniBand support. MVP is scoped to TCP for now.
-        _ensure_lnet_tcp(_get_default_interface())
-        _persist_lnet_config()
+        # Configure LNet
+        try:
+            networks = lnet.parse_network_config(self.lnet_networks_spec)
+            lnet.init(networks=networks)
+        except LNetError as e:
+            raise Error(str(e)) from e
 
     def supported(self) -> bool:
         """Check if underlying base supports mounting shares."""
@@ -293,78 +269,3 @@ def _get_endpoint_and_opts(info: FilesystemInfo, enable_lustre: bool) -> tuple[s
             raise Error(f"unsupported filesystem type `{info.filesystem_type()}`")
 
     return endpoint, options
-
-
-def _ensure_lnet_tcp(interface: str) -> None:
-    """Ensure an LNet TCP network exists on the given interface. Idempotent.
-
-    Args:
-        interface: Name of the network interface.
-
-    Raises:
-        Error: If configuring the LNet TCP network fails.
-    """
-    try:
-        result = subprocess.run([LNETCTL_EXECUTABLE, "net", "show", "--net", "tcp"])
-        if result.returncode != 0:
-            subprocess.run(
-                [LNETCTL_EXECUTABLE, "net", "add", "--net", "tcp", "--if", interface], check=True
-            )
-        # TODO: verify the tcp network is assigned to the correct interface?
-    except (subprocess.CalledProcessError, FileNotFoundError) as e:
-        _logger.error("failed to setup lnet on the system", exc_info=e)
-        raise Error(str(e))
-
-
-def _get_default_interface() -> str:
-    """Return the default network interface name for this unit.
-
-    Returns:
-        The name of the default network interface.
-
-    Raises:
-        Error: If querying or parsing the default network interface fails.
-    """
-    try:
-        result = subprocess.run(
-            [IP_EXECUTABLE, "-json", "route", "show", "default"],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-    except (subprocess.CalledProcessError, FileNotFoundError) as e:
-        _logger.error("failed to get the default network interface", exc_info=e)
-        raise Error(str(e))
-
-    try:
-        routes = json.loads(result.stdout)
-    except json.JSONDecodeError as e:
-        _logger.error("failed to parse default route data", exc_info=e)
-        raise Error(str(e))
-
-    try:
-        return routes[0]["dev"]
-    except (IndexError, KeyError) as e:
-        _logger.error("could not determine the default network interface name", exc_info=e)
-        raise Error(str(e))
-
-
-def _persist_lnet_config() -> None:
-    """Export and persist the current LNet configuration.
-
-    Raises:
-        Error: If exporting or writing the LNet configuration fails.
-    """
-    try:
-        result = subprocess.check_output([LNETCTL_EXECUTABLE, "export", "--backup"], text=True)
-
-        # Write to temp file then atomically replace existing config. Avoids leaving partial config
-        # file if write process is interrupted.
-        tmp = LUSTRE_LNET_CONF.with_name(f".{LUSTRE_LNET_CONF.name}.tmp")
-        tmp.unlink(missing_ok=True)  # Clean up any failed previous attempt.
-        tmp.touch(mode=0o600)
-        tmp.write_text(result)
-        tmp.replace(LUSTRE_LNET_CONF)
-    except (subprocess.CalledProcessError, FileNotFoundError, OSError) as e:
-        _logger.error("failed to write lnet configuration to the system", exc_info=e)
-        raise Error(str(e))

--- a/charms/filesystem-client/src/utils/manager.py
+++ b/charms/filesystem-client/src/utils/manager.py
@@ -116,7 +116,7 @@ class MountsManager:
         self._master_file = pathlib.Path(f"/etc/auto.master.d/{unit_id}.autofs")
         self._autofs_file = pathlib.Path(f"/etc/auto.{unit_id}")
         self.enable_lustre = False
-        self.lnet_networks_spec = ""
+        self.lnet_networks: dict[str, list[str]] | None = None
 
     def _packages(self) -> list[apt.DebianPackage]:
         """List of packages required by the client."""
@@ -183,8 +183,7 @@ class MountsManager:
 
         # Configure LNet
         try:
-            networks = lnet.parse_network_config(self.lnet_networks_spec)
-            lnet.init(networks=networks)
+            lnet.init(networks=self.lnet_networks)
         except LNetError as e:
             raise Error(str(e)) from e
 

--- a/charms/filesystem-client/tests/unit/test_charm.py
+++ b/charms/filesystem-client/tests/unit/test_charm.py
@@ -100,3 +100,25 @@ def test_enable_lustre_sets_manager_flag(
     assert state_out.unit_status == testing.BlockedStatus(
         "Missing `mountpoint` config or `mount` integration"
     )
+
+
+def test_lnet_networks_config_parsed(
+    ctx: testing.Context, mock_mounts_manager: MagicMock
+) -> None:
+    """The lnet-networks config is parsed before being passed to the manager."""
+    state_in = testing.State(
+        config={
+            "enable-lustre": True,
+            "lnet-networks": "tcp=eth0; o2ib=ib0,ib1",
+        }
+    )
+    mock_mounts_manager.supported.return_value = True
+    mock_mounts_manager.is_setup.return_value = True
+    mock_mounts_manager.mounts = MagicMock()
+
+    ctx.run(ctx.on.config_changed(), state_in)
+
+    assert mock_mounts_manager.lnet_networks == {
+        "tcp": ["eth0"],
+        "o2ib": ["ib0", "ib1"],
+    }

--- a/charms/filesystem-client/tests/unit/test_manager.py
+++ b/charms/filesystem-client/tests/unit/test_manager.py
@@ -1,0 +1,63 @@
+# Copyright 2024-2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Unit tests for `utils.manager.MountsManager`."""
+
+import pathlib
+from unittest.mock import MagicMock
+
+import pytest
+from lustre_ops.errors import LNetError
+from pytest_mock import MockerFixture
+from utils.manager import Error, MountsManager
+
+
+@pytest.fixture
+def manager(mocker: MockerFixture, tmp_path: pathlib.Path) -> MountsManager:
+    """Mock MountsManager with package and autofs concerns stubbed out."""
+    charm = MagicMock()
+    charm.unit.name = "filesystem-client/0"
+    mgr = MountsManager(charm)
+    # Stub out package installation and autofs file handling so setup() reaches the lnet path.
+    mocker.patch.object(mgr, "_packages", return_value=[])
+    mocker.patch.object(mgr, "_master_file", tmp_path / "master")
+    mocker.patch.object(mgr, "_autofs_file", tmp_path / "autofs")
+    return mgr
+
+
+class TestSetupLnet:
+    """LNet configuration wiring in MountsManager.setup()."""
+
+    def test_lustre_disabled_skips_lnet(
+        self, manager: MountsManager, mocker: MockerFixture
+    ) -> None:
+        """LNet is not configured when enable_lustre is False."""
+        mock_init = mocker.patch("utils.manager.lnet.init")
+        manager.enable_lustre = False
+
+        manager.setup()
+
+        mock_init.assert_not_called()
+
+    def test_config_spec_forwarded(self, manager: MountsManager, mocker: MockerFixture) -> None:
+        """A non-empty lnet-networks spec is parsed and forwarded to lnet.init."""
+        mock_init = mocker.patch("utils.manager.lnet.init")
+        manager.enable_lustre = True
+        manager.lnet_networks_spec = "tcp=eth0; o2ib=ib0,ib1"
+
+        manager.setup()
+
+        mock_init.assert_called_once()
+        _, kwargs = mock_init.call_args
+        networks = kwargs["networks"]
+        assert networks == {"tcp": ["eth0"], "o2ib": ["ib0", "ib1"]}
+
+    def test_lnet_error_wrapped(self, manager: MountsManager, mocker: MockerFixture) -> None:
+        """An LNetError from init is wrapped as a manager Error."""
+        lnet_error_message = "test lnet error message"
+        mocker.patch("utils.manager.lnet.init", side_effect=LNetError(lnet_error_message))
+        manager.enable_lustre = True
+        manager.lnet_networks_spec = ""
+
+        with pytest.raises(Error, match=lnet_error_message):
+            manager.setup()

--- a/charms/filesystem-client/tests/unit/test_manager.py
+++ b/charms/filesystem-client/tests/unit/test_manager.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock
 import pytest
 from lustre_ops.errors import LNetError
 from pytest_mock import MockerFixture
-from utils.manager import Error, MountsManager
+from utils.manager import Error, MountsManager, lnet
 
 
 @pytest.fixture
@@ -32,7 +32,7 @@ class TestSetupLnet:
         self, manager: MountsManager, mocker: MockerFixture
     ) -> None:
         """LNet is not configured when enable_lustre is False."""
-        mock_init = mocker.patch("utils.manager.lnet.init")
+        mock_init = mocker.patch.object(lnet, "init")
         manager.enable_lustre = False
 
         manager.setup()
@@ -41,7 +41,7 @@ class TestSetupLnet:
 
     def test_config_spec_forwarded(self, manager: MountsManager, mocker: MockerFixture) -> None:
         """A non-empty lnet-networks spec is parsed and forwarded to lnet.init."""
-        mock_init = mocker.patch("utils.manager.lnet.init")
+        mock_init = mocker.patch.object(lnet, "init")
         manager.enable_lustre = True
         manager.lnet_networks_spec = "tcp=eth0; o2ib=ib0,ib1"
 
@@ -55,7 +55,7 @@ class TestSetupLnet:
     def test_lnet_error_wrapped(self, manager: MountsManager, mocker: MockerFixture) -> None:
         """An LNetError from init is wrapped as a manager Error."""
         lnet_error_message = "test lnet error message"
-        mocker.patch("utils.manager.lnet.init", side_effect=LNetError(lnet_error_message))
+        mocker.patch.object(lnet, "init", side_effect=LNetError(lnet_error_message))
         manager.enable_lustre = True
         manager.lnet_networks_spec = ""
 

--- a/charms/filesystem-client/tests/unit/test_manager.py
+++ b/charms/filesystem-client/tests/unit/test_manager.py
@@ -12,7 +12,7 @@ from pytest_mock import MockerFixture
 from utils.manager import Error, MountsManager, lnet
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def manager(mocker: MockerFixture, tmp_path: pathlib.Path) -> MountsManager:
     """Mock MountsManager with package and autofs concerns stubbed out."""
     charm = MagicMock()

--- a/charms/filesystem-client/tests/unit/test_manager.py
+++ b/charms/filesystem-client/tests/unit/test_manager.py
@@ -39,25 +39,22 @@ class TestSetupLnet:
 
         mock_init.assert_not_called()
 
-    def test_config_spec_forwarded(self, manager: MountsManager, mocker: MockerFixture) -> None:
-        """A non-empty lnet-networks spec is parsed and forwarded to lnet.init."""
+    def test_networks_forwarded(self, manager: MountsManager, mocker: MockerFixture) -> None:
+        """Configured LNet networks are forwarded to lnet.init."""
         mock_init = mocker.patch.object(lnet, "init")
         manager.enable_lustre = True
-        manager.lnet_networks_spec = "tcp=eth0; o2ib=ib0,ib1"
+        manager.lnet_networks = {"tcp": ["eth0"], "o2ib": ["ib0", "ib1"]}
 
         manager.setup()
 
-        mock_init.assert_called_once()
-        _, kwargs = mock_init.call_args
-        networks = kwargs["networks"]
-        assert networks == {"tcp": ["eth0"], "o2ib": ["ib0", "ib1"]}
+        mock_init.assert_called_once_with(networks=manager.lnet_networks)
 
     def test_lnet_error_wrapped(self, manager: MountsManager, mocker: MockerFixture) -> None:
         """An LNetError from init is wrapped as a manager Error."""
         lnet_error_message = "test lnet error message"
         mocker.patch.object(lnet, "init", side_effect=LNetError(lnet_error_message))
         manager.enable_lustre = True
-        manager.lnet_networks_spec = ""
+        manager.lnet_networks = None
 
         with pytest.raises(Error, match=lnet_error_message):
             manager.setup()

--- a/charms/lustre-server/charmcraft.yaml
+++ b/charms/lustre-server/charmcraft.yaml
@@ -43,3 +43,22 @@ peers:
 provides:
   filesystem:
     interface: filesystem_info
+
+config:
+  options:
+    lnet-networks:
+      type: string
+      default: ""
+      description: |
+        LNet network configuration. Syntax:
+
+        "tcp=eth0; o2ib0=ib0,ib1"
+
+        Each network is "<name>=<iface>[,<iface>...]" where <name> is the full LNet network name
+        (examples: tcp0, o2ib1). Multiple interfaces form a multi-rail network.
+
+        Leave empty to auto-detect a setup of a "tcp" network on the default route interface and an
+        "o2ib" network on all RDMA devices.
+
+        This configuration is used only when the charm is first deployed. Changes made to this value
+        after deployment will not be applied.

--- a/charms/lustre-server/charmcraft.yaml
+++ b/charms/lustre-server/charmcraft.yaml
@@ -4,9 +4,9 @@
 name: lustre-server
 type: charm
 title: Lustre Parallel File System
-summary: Provides the Lustre parallel file system.
+summary: Charmed operator for the Lustre parallel file system.
 description: |
-  This charm enables the deployment and management of the Lustre parallel file system.
+  This charm deploys and manages the Lustre parallel file system.
 
   This single charm provides all Lustre server components: MGS (Management Server), MDS (Metadata
   Server), and OSS (Object Storage Server) and intelligently provisions each. Storage targets are
@@ -17,6 +17,15 @@ description: |
 
   It is useful for HPC and data-intensive teams looking for a high-throughput, scalable, distributed
   file system.
+
+  The charm is a core component of Charmed HPC. For more information about Charmed HPC, view the
+  [full documentation](https://ubuntu.com/hpc/docs/latest).
+links:
+  contact: https://matrix.to/#/#hpc:ubuntu.com
+  documentation: https://ubuntu.com/hpc/docs/latest
+  website: https://ubuntu.com/hpc
+  source: https://github.com/canonical/filesystem-charms
+  issues: https://github.com/canonical/filesystem-charms/issues
 
 platforms:
   ubuntu@26.04:amd64:

--- a/charms/lustre-server/pyproject.toml
+++ b/charms/lustre-server/pyproject.toml
@@ -5,7 +5,10 @@
 name = "lustre-server"
 version = "0.0.1"
 requires-python = "==3.14.*"
-dependencies = ["ops", "pydantic", "charmlibs-apt", "charmed-hpc-libs[ops]"]
+dependencies = ["ops", "pydantic", "charmlibs-apt", "charmed-hpc-libs[ops]", "lustre-ops"]
+
+[tool.uv.sources]
+lustre-ops = { workspace = true }
 
 [tool.repository]
 libraries = [

--- a/charms/lustre-server/pyproject.toml
+++ b/charms/lustre-server/pyproject.toml
@@ -7,9 +7,6 @@ version = "0.0.1"
 requires-python = "==3.14.*"
 dependencies = ["ops", "pydantic", "charmlibs-apt", "charmed-hpc-libs[ops]", "lustre-ops"]
 
-[tool.uv.sources]
-lustre-ops = { workspace = true }
-
 [tool.repository]
 libraries = [
     "filesystem-client.filesystem_info"

--- a/charms/lustre-server/src/charm.py
+++ b/charms/lustre-server/src/charm.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 refresh_check_lustre = refresh(hook=check_lustre)
 
 
-class CharmStatuses(StrEnum):
+class _CharmStatus(StrEnum):
     """Charm status messages."""
 
     REPO_SETUP = "Setting up package repository"
@@ -74,43 +74,43 @@ class LustreCharm(ops.CharmBase):
     def _on_install(self, _: ops.InstallEvent):
         """Install Lustre packages."""
         # Lustre packages are not in the Ubuntu archive. Add an external repository.
-        self.unit.status = ops.MaintenanceStatus(CharmStatuses.REPO_SETUP)
+        self.unit.status = ops.MaintenanceStatus(_CharmStatus.REPO_SETUP)
         try:
             ppa.setup_lustre_repository()
         except RepositoryError as e:
             logger.exception("failed to set up Lustre package repository: %s", e)
-            self.unit.status = ops.BlockedStatus(CharmStatuses.FAILED_REPO_SETUP)
+            self.unit.status = ops.BlockedStatus(_CharmStatus.FAILED_REPO_SETUP)
             return
 
-        self.unit.status = ops.MaintenanceStatus(CharmStatuses.PACKAGE_INSTALL)
+        self.unit.status = ops.MaintenanceStatus(_CharmStatus.PACKAGE_INSTALL)
         try:
             apt.add_package(LUSTRE_PACKAGES)
         except (apt.PackageNotFoundError, apt.PackageError) as e:
             logger.exception("failed to install packages: %s. reason: %s", LUSTRE_PACKAGES, e)
-            self.unit.status = ops.BlockedStatus(CharmStatuses.failed_install(LUSTRE_PACKAGES))
+            self.unit.status = ops.BlockedStatus(_CharmStatus.failed_install(LUSTRE_PACKAGES))
             return
 
-        self.unit.status = ops.MaintenanceStatus(CharmStatuses.LNET_INIT)
+        self.unit.status = ops.MaintenanceStatus(_CharmStatus.LNET_INIT)
         try:
             networks = lnet.parse_network_config(self.typed_config.lnet_networks)
             lnet.init(networks=networks)
         except LNetError as e:
             logger.exception("failed to initialize LNet: %s", e)
-            self.unit.status = ops.BlockedStatus(CharmStatuses.FAILED_LNET_INIT)
+            self.unit.status = ops.BlockedStatus(_CharmStatus.FAILED_LNET_INIT)
             return
 
-        self.unit.status = ops.MaintenanceStatus(CharmStatuses.PREPARING_SERVICES)
+        self.unit.status = ops.MaintenanceStatus(_CharmStatus.PREPARING_SERVICES)
 
     @refresh_check_lustre
     def _on_start(self, _: ops.StartEvent):
         """Set up Lustre services."""
-        self.unit.status = ops.MaintenanceStatus(CharmStatuses.STARTING_SERVICES)
+        self.unit.status = ops.MaintenanceStatus(_CharmStatus.STARTING_SERVICES)
 
         try:
             data = self.peers.get_app_data()
         except LustrePeerError as e:
             logger.exception("failed to read peer relation data: %s", e)
-            raise StopCharm(ops.BlockedStatus(CharmStatuses.FAILED_PEER_DATA))
+            raise StopCharm(ops.BlockedStatus(_CharmStatus.FAILED_PEER_DATA))
 
         mgs_unit = data.mgs_unit_name
         mgs_nids = data.mgs_nids
@@ -124,7 +124,7 @@ class LustreCharm(ops.CharmBase):
                     self.peers.mgs_nids_published()
                 except (LustrePeerError, LustreFilesystemError) as e:
                     logger.exception("failed to set up MGS+MDS: %s", e)
-                    raise StopCharm(ops.BlockedStatus(CharmStatuses.FAILED_MGS_MDS_SETUP))
+                    raise StopCharm(ops.BlockedStatus(_CharmStatus.FAILED_MGS_MDS_SETUP))
 
             # Initial non-leaders are OSSes and must wait for leader to publish MGS info in the peer
             # relation before starting.
@@ -140,7 +140,7 @@ class LustreCharm(ops.CharmBase):
                 lustre_fs.oss_setup(LUSTRE_FSNAME, self.model.unit.name, mgs_nids)
         except LustreFilesystemError as e:
             logger.exception("failed to set up Lustre services: %s", e)
-            raise StopCharm(ops.BlockedStatus(CharmStatuses.FAILED_SERVICE_SETUP))
+            raise StopCharm(ops.BlockedStatus(_CharmStatus.FAILED_SERVICE_SETUP))
 
     @refresh_check_lustre
     def _on_update_status(self, _: ops.UpdateStatusEvent) -> None:

--- a/charms/lustre-server/src/charm.py
+++ b/charms/lustre-server/src/charm.py
@@ -5,24 +5,23 @@
 """Charm for the Lustre file system."""
 
 import logging
-import platform
 from enum import StrEnum
-from subprocess import CalledProcessError
 
 import lustre_fs
 import ops
 from charmed_hpc_libs.ops import StopCharm, refresh
 from charmlibs import apt
 from charms.filesystem_client.v0.filesystem_info import FilesystemProvides
+from config import LustreConfig
 from constants import (
     FILESYSTEM_PEER_RELATION,
     FILESYSTEM_RELATION,
     LUSTRE_FSNAME,
     LUSTRE_PACKAGES,
-    LUSTRE_REPOSITORY_KEY,
-    LUSTRE_REPOSITORY_URI,
 )
 from errors import LustreFilesystemError, LustrePeerError
+from lustre_ops import lnet, ppa
+from lustre_ops.errors import LNetError, RepositoryError
 from lustre_peer import LustrePeerObserver
 from state import check_lustre
 
@@ -34,12 +33,10 @@ class CharmStatuses(StrEnum):
     """Charm status messages."""
 
     REPO_SETUP = "Setting up package repository"
-    FAILED_OS_CODENAME = "Failed to determine OS version codename"
-    FAILED_IMPORT_GPG_KEY = "Failed to import GPG key for Lustre package repository"
-    FAILED_ADD_REPO = "Failed to add Lustre package repository"
+    FAILED_REPO_SETUP = "Failed to set up Lustre package repository"
     PACKAGE_INSTALL = "Installing Lustre packages"
     LNET_INIT = "Initializing LNet"
-    FAILED_LNET_INIT = "Lustre filesystem initialization failed"
+    FAILED_LNET_INIT = "LNet initialization failed"
     PREPARING_SERVICES = "Preparing to start Lustre services"
     STARTING_SERVICES = "Starting Lustre services"
     FAILED_PEER_DATA = "Failed to get peer relation app data"
@@ -67,8 +64,9 @@ class LustreCharm(ops.CharmBase):
     def __init__(self, framework: ops.Framework):
         """Initialize the Lustre charm and event observers."""
         super().__init__(framework)
-        self.peers = LustrePeerObserver(self)
+        self.typed_config = self.load_config(LustreConfig, errors="blocked")
         self.filesystem = FilesystemProvides(self, FILESYSTEM_RELATION, FILESYSTEM_PEER_RELATION)
+        self.peers = LustrePeerObserver(self)
         framework.observe(self.on.install, self._on_install)
         framework.observe(self.on.start, self._on_start)
         framework.observe(self.on.update_status, self._on_update_status)
@@ -77,8 +75,11 @@ class LustreCharm(ops.CharmBase):
         """Install Lustre packages."""
         # Lustre packages are not in the Ubuntu archive. Add an external repository.
         self.unit.status = ops.MaintenanceStatus(CharmStatuses.REPO_SETUP)
-        success = self._setup_lustre_repository()
-        if not success:
+        try:
+            ppa.setup_lustre_repository()
+        except RepositoryError as e:
+            logger.exception("failed to set up Lustre package repository: %s", e)
+            self.unit.status = ops.BlockedStatus(CharmStatuses.FAILED_REPO_SETUP)
             return
 
         self.unit.status = ops.MaintenanceStatus(CharmStatuses.PACKAGE_INSTALL)
@@ -91,9 +92,10 @@ class LustreCharm(ops.CharmBase):
 
         self.unit.status = ops.MaintenanceStatus(CharmStatuses.LNET_INIT)
         try:
-            lustre_fs.init()
-        except LustreFilesystemError as e:
-            logger.exception("failed to initialize Lustre filesystem: %s", e)
+            networks = lnet.parse_network_config(self.typed_config.lnet_networks)
+            lnet.init(networks=networks)
+        except LNetError as e:
+            logger.exception("failed to initialize LNet: %s", e)
             self.unit.status = ops.BlockedStatus(CharmStatuses.FAILED_LNET_INIT)
             return
 
@@ -111,15 +113,15 @@ class LustreCharm(ops.CharmBase):
             raise StopCharm(ops.BlockedStatus(CharmStatuses.FAILED_PEER_DATA))
 
         mgs_unit = data.mgs_unit_name
-        mgs_nid = data.mgs_nid
+        mgs_nids = data.mgs_nids
 
-        if mgs_unit is None or mgs_nid is None:
+        if mgs_unit is None or not mgs_nids:
             # No MGS has been published yet. This is initial deployment.
             if self.unit.is_leader():
                 # Initial leader is MGS+MDS for lifetime of deployment.
                 try:
                     lustre_fs.mgs_mds_setup(LUSTRE_FSNAME)
-                    self.peers.mgs_nid_published()
+                    self.peers.mgs_nids_published()
                 except (LustrePeerError, LustreFilesystemError) as e:
                     logger.exception("failed to set up MGS+MDS: %s", e)
                     raise StopCharm(ops.BlockedStatus(CharmStatuses.FAILED_MGS_MDS_SETUP))
@@ -135,7 +137,7 @@ class LustreCharm(ops.CharmBase):
             else:
                 # If this is a slow initial deployment, OSS will still need to wait for the peer
                 # relation event that marks itself ready before any filesystem info is published.
-                lustre_fs.oss_setup(LUSTRE_FSNAME, self.model.unit.name, mgs_nid)
+                lustre_fs.oss_setup(LUSTRE_FSNAME, self.model.unit.name, mgs_nids)
         except LustreFilesystemError as e:
             logger.exception("failed to set up Lustre services: %s", e)
             raise StopCharm(ops.BlockedStatus(CharmStatuses.FAILED_SERVICE_SETUP))
@@ -143,49 +145,6 @@ class LustreCharm(ops.CharmBase):
     @refresh_check_lustre
     def _on_update_status(self, _: ops.UpdateStatusEvent) -> None:
         """Check the health of Lustre services and update unit status."""
-
-    def _setup_lustre_repository(self) -> bool:
-        """Set up the Lustre package repository.
-
-        Returns:
-            True if the repository was successfully configured,
-            False otherwise.
-        """
-        try:
-            release = platform.freedesktop_os_release()["VERSION_CODENAME"]
-        except KeyError as e:
-            logger.exception("failed to determine OS version codename: %s", e)
-            self.unit.status = ops.BlockedStatus(CharmStatuses.FAILED_OS_CODENAME)
-            return False
-
-        logger.debug("detected OS release codename: %s", release)
-
-        repo = apt.DebianRepository(
-            enabled=True,
-            repotype="deb",
-            uri=LUSTRE_REPOSITORY_URI,
-            release=release,
-            groups=["main"],
-            filename="lustre-repo",
-        )
-        repositories = apt.RepositoryMapping()
-
-        try:
-            repo.import_key(LUSTRE_REPOSITORY_KEY)
-        except apt.GPGKeyError as e:
-            logger.exception("failed to import GPG key: %s", e)
-            self.unit.status = ops.BlockedStatus(CharmStatuses.FAILED_IMPORT_GPG_KEY)
-            return False
-
-        try:
-            repositories.add(repo)
-            apt.update()
-        except CalledProcessError as e:
-            logger.exception("failed to add repository: %s", e)
-            self.unit.status = ops.BlockedStatus(CharmStatuses.FAILED_ADD_REPO)
-            return False
-
-        return True
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/charms/lustre-server/src/config.py
+++ b/charms/lustre-server/src/config.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Lustre charm configuration model."""
+
+import pydantic
+
+
+class LustreConfig(pydantic.BaseModel):
+    """Lustre charm configuration model."""
+
+    lnet_networks: str = pydantic.Field("")

--- a/charms/lustre-server/src/config.py
+++ b/charms/lustre-server/src/config.py
@@ -4,10 +4,10 @@
 
 """Lustre charm configuration model."""
 
-import pydantic
+from pydantic import BaseModel
 
 
-class LustreConfig(pydantic.BaseModel):
+class LustreConfig(BaseModel):
     """Lustre charm configuration model."""
 
-    lnet_networks: str = pydantic.Field("")
+    lnet_networks: str = ""

--- a/charms/lustre-server/src/constants.py
+++ b/charms/lustre-server/src/constants.py
@@ -10,7 +10,6 @@ FILESYSTEM_RELATION = "filesystem"
 FILESYSTEM_PEER_RELATION = "filesystem-peer"
 
 LUSTRE_FSNAME = "lustrefs"
-LUSTRE_LNET_CONF = Path("/etc/lnet.conf")
 LUSTRE_MGS_MDT_DATASET_PREFIX = "mgsmdt"
 LUSTRE_MGS_MDT_MOUNTPOINT = Path("/mnt/mgs_mdt")
 LUSTRE_OST_DATASET_PREFIX = "ost"
@@ -18,42 +17,7 @@ LUSTRE_OST_PARENT_DIRECTORY = "/mnt"
 
 # zfsutils-linux is needed but is not an explicit dependency of the Lustre debs.
 LUSTRE_PACKAGES = ["lustre-server-modules-dkms", "lustre-server-utils", "zfsutils-linux"]
-LUSTRE_REPOSITORY_KEY = """-----BEGIN PGP PUBLIC KEY BLOCK-----
-Comment: Hostname:
-Version: Hockeypuck 2.2
 
-xsFNBGTuZb8BEACtJ1CnZe6/hv84DceHv+a54y3Pqq0gqED0xhTKnbj/E2ByJpmT
-NlDNkpeITwPAAN1e3824Me76Qn31RkogTMoPJ2o2XfG253RXd67MPxYhfKTJcnM3
-CEkmeI4u2Lynh3O6RQ08nAFS2AGTeFVFH2GPNWrfOsGZW03Jas85TZ0k7LXVHiBs
-W6qonbsFJhshvwC3SryG4XYT+z/+35x5fus4rPtMrrEOD65hij7EtQNaE8owuAju
-Kcd0m2b+crMXNcllWFWmYMV0VjksQvYD7jwGrWeKs+EeHgU8ZuqaIP4pYHvoQjag
-umqnH9Qsaq5NAXiuAIAGDIIV4RdAfQIR4opGaVgIFJdvoSwYe3oh2JlrLPBlyxyY
-dayDifd3X8jxq6/oAuyH1h5K/QLs46jLSR8fUbG98SCHlRmvozTuWGk+e07ALtGe
-sGv78ToHKwoM2buXaTTHMwYwu7Rx8LZ4bZPHdersN1VW/m9yn1n5hMzwbFKy2s6/
-D4Q2ZBsqlN+5aW2q0IUmO+m0GhcdaDv8U7RVto1cWWPr50HhiCi7Yvei1qZiD9jq
-57oYZVqTUNCTPxi6NeTOdEc+YqNynWNArx4PHh38LT0bqKtlZCGHNfoAJLPVYhbB
-b2AHj9edYtHU9AAFSIy+HstET6P0UDxy02IeyE2yxoUBqdlXyv6FL44E+wARAQAB
-zRxMYXVuY2hwYWQgUFBBIGZvciBVYnVudHUgSFBDwsGOBBMBCgA4FiEErocSHcPk
-oLD4H/Aj9tDF1ca+s3sFAmTuZb8CGwMFCwkIBwIGFQoJCAsCBBYCAwECHgECF4AA
-CgkQ9tDF1ca+s3sz3w//RNawsgydrutcbKf0yphDhzWS53wgfrs2KF1KgB0u/H+u
-6Kn2C6jrVM0vuY4NKpbEPCduOj21pTCepL6PoCLv++tICOLVok5wY7Zn3WQFq0js
-Iy1wO5t3kA1cTD/05v/qQVBGZ2j4DsJo33iMcQS5AjHvSr0nu7XSvDDEE3cQE55D
-87vL7lgGjuTOikPh5FpCoS1gpemBfwm2Lbm4P8vGOA4/witRjGgfC1fv1idUnZLM
-TbGrDlhVie8pX2kgB6yTYbJ3P3kpC1ZPpXSRWO/cQ8xoYpLBTXOOtqwZZUnxyzHh
-gM+hv42vPTOnCo+apD97/VArsp59pDqEVoAtMTk72fdBqR+BB77g2hBkKESgQIEq
-EiE1/TOISioMkE0AuUdaJ2ebyQXugSHHuBaqbEC47v8t5DVN5Qr9OriuzCuSDNFn
-6SBHpahN9ZNi9w0A/Yh1+lFfpkVw2t04Q2LNuupqOpW+h3/62AeUqjUIAIrmfeML
-IDRE2VdquYdIXKuhNvfpJYGdyvx/wAbiAeBWg0uPSepwTfTG59VPQmj0FtalkMnN
-ya2212K5q68O5eXOfCnGeMvqIXxqzpdukxSZnLkgk40uFJnJVESd/CxHquqHPUDE
-fy6i2AnB3kUI27D4HY2YSlXLSRbjiSxTfVwNCzDsIh7Czefsm6ITK2+cVWs0hNQ=
-=cs1s
------END PGP PUBLIC KEY BLOCK-----
-"""
-LUSTRE_REPOSITORY_URI = "https://ppa.launchpadcontent.net/ubuntu-hpc/lustre-2.17/ubuntu/"
-
-IP_EXECUTABLE = "/usr/sbin/ip"
-LCTL_EXECUTABLE = "/usr/sbin/lctl"
-LNETCTL_EXECUTABLE = "/usr/sbin/lnetctl"
 MKFS_LUSTRE_EXECUTABLE = "/usr/sbin/mkfs.lustre"
 MOUNT_EXECUTABLE = "/usr/bin/mount"
 TRUNCATE_EXECUTABLE = "/usr/bin/truncate"

--- a/charms/lustre-server/src/lustre_fs.py
+++ b/charms/lustre-server/src/lustre_fs.py
@@ -4,16 +4,11 @@
 
 """Lustre filesystem operations."""
 
-import json
 import logging
 import subprocess
 from pathlib import Path
 
 from constants import (
-    IP_EXECUTABLE,
-    LCTL_EXECUTABLE,
-    LNETCTL_EXECUTABLE,
-    LUSTRE_LNET_CONF,
     LUSTRE_MGS_MDT_DATASET_PREFIX,
     LUSTRE_MGS_MDT_MOUNTPOINT,
     LUSTRE_OST_DATASET_PREFIX,
@@ -27,36 +22,6 @@ from constants import (
 from errors import LustreFilesystemError
 
 _logger = logging.getLogger(__name__)
-
-
-def init() -> None:
-    """Initialize Lustre by bringing up LNet. Idempotent.
-
-    Raises:
-        LustreFilesystemError: If LNet configuration fails.
-    """
-    _ensure_lnet_tcp(_get_default_interface())
-    _persist_lnet_config()
-
-
-def get_nids() -> list[str]:
-    """Return all Lustre NIDs configured on this unit.
-
-    Returns:
-        A list of NID strings in format <address>@<LND protocol><lnd#>. Example: ["10.0.0.5@tcp"].
-        Empty if no NIDs are configured.
-
-    Raises:
-        LustreFilesystemError: If querying the NIDs fails.
-    """
-    try:
-        result = subprocess.run(
-            [LCTL_EXECUTABLE, "list_nids"], capture_output=True, text=True, check=True
-        )
-    except (subprocess.CalledProcessError, FileNotFoundError) as e:
-        raise LustreFilesystemError("Failed to query Lustre NIDs") from e
-
-    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
 
 
 def mgs_mds_setup(fsname: str) -> None:
@@ -90,13 +55,13 @@ def mgs_mds_setup(fsname: str) -> None:
     _logger.info("MGS+MDS on pool '%s' and dataset '%s' ready", pool, dataset)
 
 
-def oss_setup(fsname: str, unit_name: str, mgs_nid: str) -> None:
+def oss_setup(fsname: str, unit_name: str, mgs_nids: list[str]) -> None:
     """Set up an OSS on this unit. Idempotent.
 
     Args:
         fsname: Lustre filesystem name.
         unit_name: Name of this unit.
-        mgs_nid: MGS NID to use for this OSS.
+        mgs_nids: MGS NIDs to use for this OSS.
 
     Raises:
         LustreFilesystemError: If OSS setup fails.
@@ -117,11 +82,12 @@ def oss_setup(fsname: str, unit_name: str, mgs_nid: str) -> None:
     dataset = f"{LUSTRE_OST_DATASET_PREFIX}{ost_index}"
     pool = f"{fsname}-{dataset}-pool"
 
+    mgs_nids_str = ",".join(mgs_nids)
     _logger.info(
-        "Ensuring this unit is running OSS on pool '%s' and dataset '%s' with MGS NID: '%s'",
+        "Ensuring this unit is running OSS on pool '%s' and dataset '%s' with MGS NIDs: '%s'",
         pool,
         dataset,
-        mgs_nid,
+        mgs_nids_str,
     )
 
     devices = _detect_devices(pool)
@@ -133,10 +99,12 @@ def oss_setup(fsname: str, unit_name: str, mgs_nid: str) -> None:
             f"Failed to create OST zpool '{pool}' with devices {devices}"
         ) from e
 
-    _lustre_target(fsname, pool, dataset, ost_index, mkfs_flags=["--ost", f"--mgsnode={mgs_nid}"])
+    _lustre_target(
+        fsname, pool, dataset, ost_index, mkfs_flags=["--ost", f"--mgsnode={mgs_nids_str}"]
+    )
     _mount(pool, dataset, Path(LUSTRE_OST_PARENT_DIRECTORY) / dataset)
 
-    _logger.info("OST index '%s' for MGS NID '%s' ready", ost_index, mgs_nid)
+    _logger.info("OST index '%s' for MGS NIDs '%s' ready", ost_index, mgs_nids_str)
 
 
 def _detect_devices(owner: str) -> list[str]:
@@ -293,78 +261,6 @@ def _mount(pool: str, dataset: str, mountpoint: Path) -> None:
         raise LustreFilesystemError(
             f"Failed to mount Lustre target {full_dataset_name} at {mountpoint}"
         ) from e
-
-
-def _ensure_lnet_tcp(interface: str) -> None:
-    """Ensure an LNet TCP network exists on the given interface. Idempotent.
-
-    Args:
-        interface: Name of the network interface.
-
-    Raises:
-        LustreFilesystemError: If configuring the LNet TCP network fails.
-    """
-    try:
-        result = subprocess.run([LNETCTL_EXECUTABLE, "net", "show", "--net", "tcp"])
-        if result.returncode != 0:
-            subprocess.run(
-                [LNETCTL_EXECUTABLE, "net", "add", "--net", "tcp", "--if", interface], check=True
-            )
-        # TODO: verify the tcp network is assigned to the correct interface?
-    except (subprocess.CalledProcessError, FileNotFoundError) as e:
-        raise LustreFilesystemError("Failed to configure LNet") from e
-
-
-def _get_default_interface() -> str:
-    """Return the default network interface name for this unit.
-
-    Returns:
-        The name of the default network interface.
-
-    Raises:
-        LustreFilesystemError: If querying or parsing the default network interface fails.
-    """
-    try:
-        result = subprocess.run(
-            [IP_EXECUTABLE, "-json", "route", "show", "default"],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-    except (subprocess.CalledProcessError, FileNotFoundError) as e:
-        raise LustreFilesystemError("Failed to query default network interface") from e
-
-    try:
-        routes = json.loads(result.stdout)
-    except json.JSONDecodeError as e:
-        raise LustreFilesystemError("Failed to parse default route data") from e
-
-    try:
-        return routes[0]["dev"]
-    except (IndexError, KeyError) as e:
-        raise LustreFilesystemError(
-            "Failed to extract default network interface from route data"
-        ) from e
-
-
-def _persist_lnet_config() -> None:
-    """Export and persist the current LNet configuration.
-
-    Raises:
-        LustreFilesystemError: If exporting or writing the LNet configuration fails.
-    """
-    try:
-        result = subprocess.check_output([LNETCTL_EXECUTABLE, "export", "--backup"], text=True)
-
-        # Write to temp file then atomically replace existing config. Avoids leaving partial config
-        # file if write process is interrupted.
-        tmp = LUSTRE_LNET_CONF.with_name(f".{LUSTRE_LNET_CONF.name}.tmp")
-        tmp.unlink(missing_ok=True)  # Clean up any failed previous attempt.
-        tmp.touch(mode=0o600)
-        tmp.write_text(result)
-        tmp.replace(LUSTRE_LNET_CONF)
-    except (subprocess.CalledProcessError, FileNotFoundError, OSError) as e:
-        raise LustreFilesystemError("Failed to write LNet configuration data") from e
 
 
 def _pool_exists(pool: str) -> bool:

--- a/charms/lustre-server/src/lustre_peer.py
+++ b/charms/lustre-server/src/lustre_peer.py
@@ -15,6 +15,8 @@ import pydantic
 from charms.filesystem_client.v0.filesystem_info import LustreInfo
 from constants import LUSTRE_FSNAME
 from errors import LustreFilesystemError, LustrePeerError
+from lustre_ops import lnet
+from lustre_ops.errors import LNetError
 from state import check_lustre
 
 if TYPE_CHECKING:
@@ -37,12 +39,12 @@ class LustrePeerAppData(pydantic.BaseModel):
     """App-level data written by the leader to the peer relation databag.
 
     Attributes:
-        mgs_nid: The LNet NID of the MGS unit. Example: "10.0.0.5@tcp".
+        mgs_nids: The LNet NIDs of the MGS unit. Example: ["10.0.0.5@tcp"].
         mgs_unit_name: The Juju name for the MGS unit. Example: "lustre/0".
     """
 
-    mgs_nid: str | None = pydantic.Field(
-        default=None, description="LNet NID of the MGS unit. Example: '10.0.0.5@tcp'."
+    mgs_nids: list[str] = pydantic.Field(
+        default_factory=list, description="LNet NIDs of the MGS unit. Example: ['10.0.0.5@tcp']."
     )
     mgs_unit_name: str | None = pydantic.Field(
         default=None, description="Juju name for the MGS unit. Example: 'lustre/0'."
@@ -71,42 +73,44 @@ class LustrePeerObserver(ops.Object):
             charm.on[PEER_RELATION].relation_changed, self._on_relation_changed
         )
 
-    def mgs_nid_published(self) -> str:
+    def mgs_nids_published(self) -> list[str]:
         """Publish this unit as the MGS if no MGS has been assigned yet.
 
         Returns:
-            The published MGS NID string.
+            The published MGS NID strings.
 
         Raises:
-            LustrePeerError: If an error occurs publishing the MGS NID.
+            LustrePeerError: If an error occurs publishing the MGS NIDs.
         """
         if not self.model.unit.is_leader():
             raise LustrePeerError("Non-leader attempted to publish MGS NID")
 
         # Never overwrite. The original MGS unit must remain stable across leader re-elections.
         data = self.get_app_data()
-        if data.mgs_unit_name and data.mgs_nid:
+        if data.mgs_unit_name and data.mgs_nids:
             _logger.info(
-                "MGS already active on %s with NID %s. skipping publication",
+                "MGS already active on %s with NIDs %s. skipping publication",
                 data.mgs_unit_name,
-                data.mgs_nid,
+                data.mgs_nids,
             )
-            return data.mgs_nid
+            return data.mgs_nids
 
         try:
-            # TODO: support multiple NIDs. MVP scoped to a single NID.
-            mgs_nid = lustre_fs.get_nids()[0]
-        except (LustreFilesystemError, IndexError) as e:
+            mgs_nids = lnet.get_nids()
+        except LNetError as e:
             raise LustrePeerError("Failed to determine MGS NID") from e
 
-        data.mgs_nid = mgs_nid
+        if not mgs_nids:
+            raise LustrePeerError("No LNet NIDs configured on this unit")
+
+        data.mgs_nids = mgs_nids
         data.mgs_unit_name = self.model.unit.name
 
         self._set_unit_ready()
         self.set_app_data(data)
-        self._try_publish_filesystem_info(mgs_nid, LUSTRE_FSNAME)
-        _logger.info("Published MGS NID %s for unit %s", data.mgs_nid, data.mgs_unit_name)
-        return data.mgs_nid
+        self._try_publish_filesystem_info(mgs_nids, LUSTRE_FSNAME)
+        _logger.info("Published MGS NIDs %s for unit %s", data.mgs_nids, data.mgs_unit_name)
+        return data.mgs_nids
 
     def get_app_data(self) -> LustrePeerAppData:
         """Return the application data in the peer relation databag.
@@ -168,14 +172,14 @@ class LustrePeerObserver(ops.Object):
             _logger.warning("Failed to get peer relation data: %s", e)
             return
 
-        if data.mgs_unit_name is None or data.mgs_nid is None:
+        if data.mgs_unit_name is None or not data.mgs_nids:
             _logger.warning("MGS data not yet published. cannot configure Lustre services.")
             return
 
         # OSS service must not be enabled on MGS+MDS unit
         if self.model.unit.name != data.mgs_unit_name:
             try:
-                lustre_fs.oss_setup(LUSTRE_FSNAME, self.model.unit.name, data.mgs_nid)
+                lustre_fs.oss_setup(LUSTRE_FSNAME, self.model.unit.name, data.mgs_nids)
             except LustreFilesystemError as e:
                 _logger.exception("failed to set up OSS: %s", e)
                 self.model.unit.status = ops.BlockedStatus(CharmStatuses.FAILED_OSS_SETUP)
@@ -203,7 +207,7 @@ class LustrePeerObserver(ops.Object):
             # the publish attempt occurs after the unit sets itself ready, so no further event is
             # needed.
             try:
-                self._try_publish_filesystem_info(data.mgs_nid, LUSTRE_FSNAME)
+                self._try_publish_filesystem_info(data.mgs_nids, LUSTRE_FSNAME)
             except LustrePeerError as e:
                 _logger.exception("failed to publish filesystem info: %s", e)
                 self.model.unit.status = ops.BlockedStatus(
@@ -251,11 +255,11 @@ class LustrePeerObserver(ops.Object):
         data.ready = True
         self.set_unit_data(data)
 
-    def _try_publish_filesystem_info(self, mgs_nid: str, fs_name: str) -> None:
+    def _try_publish_filesystem_info(self, mgs_nids: list[str], fs_name: str) -> None:
         """Publish Lustre info to the filesystem relation only if all units in the cluster are ready."""
         if not self._all_units_ready():
             _logger.debug("not all units ready yet, waiting to set filesystem info")
             return
 
         _logger.info("all units report ready, publishing filesystem info")
-        self._charm.filesystem.set_info(LustreInfo(mgs_ids=[mgs_nid], fs_name=fs_name))
+        self._charm.filesystem.set_info(LustreInfo(mgs_ids=mgs_nids, fs_name=fs_name))

--- a/charms/lustre-server/src/lustre_peer.py
+++ b/charms/lustre-server/src/lustre_peer.py
@@ -27,8 +27,8 @@ _logger = logging.getLogger(__name__)
 PEER_RELATION = "lustre-peer"
 
 
-class CharmStatuses(StrEnum):
-    """Charm status messages."""
+class _LustrePeerStatus(StrEnum):
+    """Charm status messages for the Lustre peer observer."""
 
     FAILED_OSS_SETUP = "Failed to set up OSS"
     FAILED_PUBLISH_FILESYSTEM_INFO = "Failed to publish filesystem info to peer relation"
@@ -182,14 +182,14 @@ class LustrePeerObserver(ops.Object):
                 lustre_fs.oss_setup(LUSTRE_FSNAME, self.model.unit.name, data.mgs_nids)
             except LustreFilesystemError as e:
                 _logger.exception("failed to set up OSS: %s", e)
-                self.model.unit.status = ops.BlockedStatus(CharmStatuses.FAILED_OSS_SETUP)
+                self.model.unit.status = ops.BlockedStatus(_LustrePeerStatus.FAILED_OSS_SETUP)
                 return
 
         try:
             self._set_unit_ready()
         except LustrePeerError as e:
             _logger.exception("failed to set unit ready: %s", e)
-            self.model.unit.status = ops.BlockedStatus(CharmStatuses.FAILED_SET_UNIT_READY)
+            self.model.unit.status = ops.BlockedStatus(_LustrePeerStatus.FAILED_SET_UNIT_READY)
             return
 
         if self.model.unit.is_leader():
@@ -211,7 +211,7 @@ class LustrePeerObserver(ops.Object):
             except LustrePeerError as e:
                 _logger.exception("failed to publish filesystem info: %s", e)
                 self.model.unit.status = ops.BlockedStatus(
-                    CharmStatuses.FAILED_PUBLISH_FILESYSTEM_INFO
+                    _LustrePeerStatus.FAILED_PUBLISH_FILESYSTEM_INFO
                 )
                 return
 

--- a/charms/lustre-server/src/state.py
+++ b/charms/lustre-server/src/state.py
@@ -127,7 +127,7 @@ def _peer_relation_app_data_check(data: "LustrePeerAppData") -> None:
     Raises:
         LustreStateError: If the MGS peer app data has not been published.
     """
-    if data.mgs_unit_name is None or data.mgs_nid is None:
+    if data.mgs_unit_name is None or not data.mgs_nids:
         status = ops.WaitingStatus(CharmStatuses.WAITING_PEER_DATA)
         raise LustreStateError(status)
 

--- a/charms/lustre-server/tests/unit/test_charm.py
+++ b/charms/lustre-server/tests/unit/test_charm.py
@@ -53,7 +53,7 @@ class TestCharmInstall:
     ) -> None:
         """Successful install."""
         out = ctx.run(ctx.on.install(), testing.State())
-        assert out.unit_status == testing.MaintenanceStatus(charm.CharmStatuses.PREPARING_SERVICES)
+        assert out.unit_status == testing.MaintenanceStatus(charm._CharmStatus.PREPARING_SERVICES)
 
     def test_lnet_networks_config_forwarded(
         self,
@@ -94,7 +94,7 @@ class TestCharmInstall:
         mock_repo_setup.side_effect = RepositoryError("failed to set up PPA")
 
         out = ctx.run(ctx.on.install(), testing.State())
-        assert out.unit_status == testing.BlockedStatus(charm.CharmStatuses.FAILED_REPO_SETUP)
+        assert out.unit_status == testing.BlockedStatus(charm._CharmStatus.FAILED_REPO_SETUP)
 
     def test_packages_error(
         self,
@@ -107,7 +107,7 @@ class TestCharmInstall:
         mocker.patch("charm.apt.add_package", side_effect=PackageError("bad package"))
 
         out = ctx.run(ctx.on.install(), testing.State())
-        expected_message = charm.CharmStatuses.failed_install(LUSTRE_PACKAGES)
+        expected_message = charm._CharmStatus.failed_install(LUSTRE_PACKAGES)
         assert out.unit_status == testing.BlockedStatus(expected_message)
 
     def test_lustre_init_error(
@@ -122,7 +122,7 @@ class TestCharmInstall:
         mock_lnet_init.side_effect = LNetError("")
 
         out = ctx.run(ctx.on.install(), testing.State())
-        assert out.unit_status == testing.BlockedStatus(charm.CharmStatuses.FAILED_LNET_INIT)
+        assert out.unit_status == testing.BlockedStatus(charm._CharmStatus.FAILED_LNET_INIT)
 
 
 class TestCharmStart:
@@ -222,7 +222,7 @@ class TestCharmStart:
 
         out = ctx.run(ctx.on.start(), testing.State(leader=True))
 
-        assert out.unit_status == testing.BlockedStatus(charm.CharmStatuses.FAILED_PEER_DATA)
+        assert out.unit_status == testing.BlockedStatus(charm._CharmStatus.FAILED_PEER_DATA)
 
     def test_leader_initial_deployment_mgs_mds_setup_error(
         self,
@@ -237,7 +237,7 @@ class TestCharmStart:
 
         out = ctx.run(ctx.on.start(), testing.State(leader=True))
 
-        assert out.unit_status == testing.BlockedStatus(charm.CharmStatuses.FAILED_MGS_MDS_SETUP)
+        assert out.unit_status == testing.BlockedStatus(charm._CharmStatus.FAILED_MGS_MDS_SETUP)
 
     def test_leader_initial_deployment_mgs_nids_published_error(
         self,
@@ -254,7 +254,7 @@ class TestCharmStart:
 
         out = ctx.run(ctx.on.start(), testing.State(leader=True))
 
-        assert out.unit_status == testing.BlockedStatus(charm.CharmStatuses.FAILED_MGS_MDS_SETUP)
+        assert out.unit_status == testing.BlockedStatus(charm._CharmStatus.FAILED_MGS_MDS_SETUP)
 
     def test_restart_mgs_unit_setup_error(
         self,
@@ -269,7 +269,7 @@ class TestCharmStart:
 
         out = ctx.run(ctx.on.start(), testing.State(leader=True))
 
-        assert out.unit_status == testing.BlockedStatus(charm.CharmStatuses.FAILED_SERVICE_SETUP)
+        assert out.unit_status == testing.BlockedStatus(charm._CharmStatus.FAILED_SERVICE_SETUP)
 
     def test_restart_oss_unit_setup_error(
         self,
@@ -285,4 +285,4 @@ class TestCharmStart:
 
         out = ctx.run(ctx.on.start(), testing.State(leader=True))
 
-        assert out.unit_status == testing.BlockedStatus(charm.CharmStatuses.FAILED_SERVICE_SETUP)
+        assert out.unit_status == testing.BlockedStatus(charm._CharmStatus.FAILED_SERVICE_SETUP)

--- a/charms/lustre-server/tests/unit/test_charm.py
+++ b/charms/lustre-server/tests/unit/test_charm.py
@@ -4,14 +4,14 @@
 """Lustre charm unit tests."""
 
 import importlib
-from subprocess import CalledProcessError
 from unittest.mock import MagicMock
 
 import charm
 import pytest
-from charmlibs.apt import GPGKeyError, PackageError
+from charmlibs.apt import PackageError
 from constants import LUSTRE_FSNAME, LUSTRE_PACKAGES
 from errors import LustreFilesystemError, LustrePeerError
+from lustre_ops.errors import LNetError, RepositoryError
 from lustre_peer import LustrePeerAppData
 from ops import testing
 from pytest_mock import MockerFixture
@@ -34,85 +34,76 @@ class TestCharmInstall:
         return mocker.patch("charm.apt", autospec=True)
 
     @pytest.fixture(scope="function")
-    def mock_os_release(self, mocker: MockerFixture) -> MagicMock:
-        """Mock platform.freedesktop_os_release."""
-        return mocker.patch(
-            "platform.freedesktop_os_release", return_value={"VERSION_CODENAME": "resolute"}
-        )
+    def mock_repo_setup(self, mocker: MockerFixture) -> MagicMock:
+        """Mock lustre-ops PPA setup."""
+        return mocker.patch("charm.ppa.setup_lustre_repository", autospec=True)
 
     @pytest.fixture(scope="function")
-    def mock_lustre_init(self, mocker: MockerFixture) -> MagicMock:
-        """Mock lustre_fs.init."""
-        return mocker.patch("charm.lustre_fs.init", autospec=True)
+    def mock_lnet_init(self, mocker: MockerFixture) -> MagicMock:
+        """Mock lustre-ops LNet init."""
+        return mocker.patch("charm.lnet.init", autospec=True)
 
     def test_success(
         self,
         ctx: testing.Context[charm.LustreCharm],
         mocker: MockerFixture,
+        mock_repo_setup: MagicMock,
         mock_apt: MagicMock,
-        mock_os_release: MagicMock,
-        mock_lustre_init: MagicMock,
+        mock_lnet_init: MagicMock,
     ) -> None:
         """Successful install."""
         out = ctx.run(ctx.on.install(), testing.State())
         assert out.unit_status == testing.MaintenanceStatus(charm.CharmStatuses.PREPARING_SERVICES)
 
-    def test_missing_version_codename(
+    def test_lnet_networks_config_forwarded(
         self,
         ctx: testing.Context[charm.LustreCharm],
-        mocker: MockerFixture,
-        mock_os_release: MagicMock,
-        mock_lustre_init: MagicMock,
-    ) -> None:
-        """OS version codename retrieval fails."""
-        mock_os_release.return_value = {}
-
-        out = ctx.run(ctx.on.install(), testing.State())
-        assert out.unit_status == testing.BlockedStatus(charm.CharmStatuses.FAILED_OS_CODENAME)
-
-    def test_repo_gpg_error(
-        self,
-        ctx: testing.Context[charm.LustreCharm],
-        mocker: MockerFixture,
-        mock_os_release: MagicMock,
-        mock_lustre_init: MagicMock,
-    ) -> None:
-        """GPG key import fails."""
-        mocker.patch("charm.apt.RepositoryMapping")
-        mocker.patch("charm.apt.update")
-
-        mock_repo = mocker.patch("charm.apt.DebianRepository").return_value
-        mock_repo.import_key.side_effect = GPGKeyError("bad key")
-
-        out = ctx.run(ctx.on.install(), testing.State())
-        assert out.unit_status == testing.BlockedStatus(charm.CharmStatuses.FAILED_IMPORT_GPG_KEY)
-
-    def test_repo_update_error(
-        self,
-        ctx: testing.Context[charm.LustreCharm],
-        mocker: MockerFixture,
+        mock_repo_setup: MagicMock,
         mock_apt: MagicMock,
-        mock_os_release: MagicMock,
-        mock_lustre_init: MagicMock,
+        mock_lnet_init: MagicMock,
     ) -> None:
-        """Repository update fails."""
-        mock_apt.update.side_effect = CalledProcessError(1, "bad cmd")
+        """The lnet-networks config is parsed and forwarded to lnet.init."""
+        ctx.run(
+            ctx.on.install(),
+            testing.State(config={"lnet-networks": "o2ib0=ib0,ib1"}),
+        )
+
+        mock_lnet_init.assert_called_once()
+        _, kwargs = mock_lnet_init.call_args
+        networks = kwargs["networks"]
+        assert networks == {"o2ib": ["ib0", "ib1"]}
+
+    def test_empty_lnet_config_auto_detects(
+        self,
+        ctx: testing.Context[charm.LustreCharm],
+        mock_repo_setup: MagicMock,
+        mock_apt: MagicMock,
+        mock_lnet_init: MagicMock,
+    ) -> None:
+        """An empty lnet-networks config triggers auto-detection (networks=None)."""
+        ctx.run(ctx.on.install(), testing.State())
+
+        mock_lnet_init.assert_called_once_with(networks=None)
+
+    def test_repo_setup_fails(
+        self,
+        ctx: testing.Context[charm.LustreCharm],
+        mock_repo_setup: MagicMock,
+    ) -> None:
+        """Repository setup failure blocks the unit."""
+        mock_repo_setup.side_effect = RepositoryError("failed to set up PPA")
 
         out = ctx.run(ctx.on.install(), testing.State())
-        assert out.unit_status == testing.BlockedStatus(charm.CharmStatuses.FAILED_ADD_REPO)
+        assert out.unit_status == testing.BlockedStatus(charm.CharmStatuses.FAILED_REPO_SETUP)
 
     def test_packages_error(
         self,
         ctx: testing.Context[charm.LustreCharm],
         mocker: MockerFixture,
-        mock_os_release: MagicMock,
-        mock_lustre_init: MagicMock,
+        mock_repo_setup: MagicMock,
+        mock_lnet_init: MagicMock,
     ) -> None:
         """Package installation fails."""
-        mocker.patch("charm.apt.RepositoryMapping")
-        mocker.patch("charm.apt.DebianRepository")
-        mocker.patch("charm.apt.update")
-
         mocker.patch("charm.apt.add_package", side_effect=PackageError("bad package"))
 
         out = ctx.run(ctx.on.install(), testing.State())
@@ -123,12 +114,12 @@ class TestCharmInstall:
         self,
         ctx: testing.Context[charm.LustreCharm],
         mocker: MockerFixture,
+        mock_repo_setup: MagicMock,
         mock_apt: MagicMock,
-        mock_os_release: MagicMock,
-        mock_lustre_init: MagicMock,
+        mock_lnet_init: MagicMock,
     ) -> None:
         """Lustre init fails."""
-        mock_lustre_init.side_effect = LustreFilesystemError("")
+        mock_lnet_init.side_effect = LNetError("")
 
         out = ctx.run(ctx.on.install(), testing.State())
         assert out.unit_status == testing.BlockedStatus(charm.CharmStatuses.FAILED_LNET_INIT)
@@ -169,9 +160,9 @@ class TestCharmStart:
         mock_peer_observer: MagicMock,
     ) -> None:
         """Leader with no MGS published: MGS+MDS successful start."""
-        nid = "10.0.0.1@tcp"
+        nids = ["10.0.0.1@tcp"]
         mock_peer_observer.return_value.get_app_data.return_value = LustrePeerAppData()
-        mock_peer_observer.return_value.mgs_nid_published.return_value = nid
+        mock_peer_observer.return_value.mgs_nids_published.return_value = nids
 
         ctx.run(ctx.on.start(), testing.State(leader=True))
 
@@ -201,7 +192,7 @@ class TestCharmStart:
         mock_peer_observer: MagicMock,
     ) -> None:
         """MGS already published. This unit is the MGS."""
-        app_data = LustrePeerAppData(mgs_nid="10.0.0.1@tcp", mgs_unit_name=f"{APP_NAME}/0")
+        app_data = LustrePeerAppData(mgs_nids=["10.0.0.1@tcp"], mgs_unit_name=f"{APP_NAME}/0")
         mock_peer_observer.return_value.get_app_data.return_value = app_data
 
         ctx.run(ctx.on.start(), testing.State(leader=True))
@@ -215,13 +206,13 @@ class TestCharmStart:
         mock_peer_observer: MagicMock,
     ) -> None:
         """MGS already published. This unit is an OSS."""
-        nid = "10.0.0.1@tcp"
-        app_data = LustrePeerAppData(mgs_nid=nid, mgs_unit_name=f"{APP_NAME}/1")
+        nids = ["10.0.0.1@tcp"]
+        app_data = LustrePeerAppData(mgs_nids=nids, mgs_unit_name=f"{APP_NAME}/1")
         mock_peer_observer.return_value.get_app_data.return_value = app_data
 
         ctx.run(ctx.on.start(), testing.State(leader=True))
 
-        mock_oss_setup.assert_called_once_with(LUSTRE_FSNAME, f"{APP_NAME}/0", nid)
+        mock_oss_setup.assert_called_once_with(LUSTRE_FSNAME, f"{APP_NAME}/0", nids)
 
     def test_peer_app_data_error(
         self, ctx: testing.Context[charm.LustreCharm], mock_peer_observer: MagicMock
@@ -248,16 +239,16 @@ class TestCharmStart:
 
         assert out.unit_status == testing.BlockedStatus(charm.CharmStatuses.FAILED_MGS_MDS_SETUP)
 
-    def test_leader_initial_deployment_mgs_nid_published_error(
+    def test_leader_initial_deployment_mgs_nids_published_error(
         self,
         ctx: testing.Context[charm.LustreCharm],
         mocker: MockerFixture,
         mock_mgs_mds_setup: MagicMock,
         mock_peer_observer: MagicMock,
     ) -> None:
-        """Leader initial deployment: mgs_nid_published fails."""
+        """Leader initial deployment: mgs_nids_published fails."""
         mock_peer_observer.return_value.get_app_data.return_value = LustrePeerAppData()
-        mock_peer_observer.return_value.mgs_nid_published.side_effect = LustrePeerError(
+        mock_peer_observer.return_value.mgs_nids_published.side_effect = LustrePeerError(
             "NID failed"
         )
 
@@ -272,7 +263,7 @@ class TestCharmStart:
         mock_peer_observer: MagicMock,
     ) -> None:
         """MGS unit restart: mgs_mds_setup fails."""
-        app_data = LustrePeerAppData(mgs_nid="10.0.0.1@tcp", mgs_unit_name=f"{APP_NAME}/0")
+        app_data = LustrePeerAppData(mgs_nids=["10.0.0.1@tcp"], mgs_unit_name=f"{APP_NAME}/0")
         mock_peer_observer.return_value.get_app_data.return_value = app_data
         mock_mgs_mds_setup.side_effect = LustreFilesystemError("mount failed")
 
@@ -287,8 +278,8 @@ class TestCharmStart:
         mock_peer_observer: MagicMock,
     ) -> None:
         """OSS unit restart: oss_setup fails."""
-        nid = "10.0.0.1@tcp"
-        app_data = LustrePeerAppData(mgs_nid=nid, mgs_unit_name=f"{APP_NAME}/1")
+        nids = ["10.0.0.1@tcp"]
+        app_data = LustrePeerAppData(mgs_nids=nids, mgs_unit_name=f"{APP_NAME}/1")
         mock_peer_observer.return_value.get_app_data.return_value = app_data
         mock_oss_setup.side_effect = LustreFilesystemError("zpool failed")
 

--- a/charms/lustre-server/tests/unit/test_lustre_fs.py
+++ b/charms/lustre-server/tests/unit/test_lustre_fs.py
@@ -26,13 +26,13 @@ def mock_run(mocker: MockerFixture) -> MagicMock:
     return mocker.patch("lustre_fs.subprocess.run")
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def pool_missing(mocker: MockerFixture) -> None:
     """Mock _pool_exists to return False."""
     mocker.patch("lustre_fs._pool_exists", return_value=False)
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def pool_exists(mocker: MockerFixture) -> None:
     """Mock _pool_exists to return True."""
     mocker.patch("lustre_fs._pool_exists", return_value=True)
@@ -207,12 +207,12 @@ class TestLustreTarget:
     DATASET = "mgsmdt0"
     FULL_DATASET = f"{POOL}/{DATASET}"
 
-    @pytest.fixture
+    @pytest.fixture(scope="function")
     def target_missing(self, mocker: MockerFixture) -> None:
         """Mock _target_exists to return False."""
         mocker.patch("lustre_fs._target_exists", return_value=False)
 
-    @pytest.fixture
+    @pytest.fixture(scope="function")
     def target_exists(self, mocker: MockerFixture) -> None:
         """Mock _target_exists to return True."""
         mocker.patch("lustre_fs._target_exists", return_value=True)

--- a/charms/lustre-server/tests/unit/test_lustre_fs.py
+++ b/charms/lustre-server/tests/unit/test_lustre_fs.py
@@ -3,8 +3,6 @@
 
 """Unit tests for lustre_fs.py — Lustre filesystem operations."""
 
-import json
-import stat
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -12,8 +10,6 @@ from unittest.mock import MagicMock
 import lustre_fs
 import pytest
 from constants import (
-    LCTL_EXECUTABLE,
-    LNETCTL_EXECUTABLE,
     LUSTRE_MGS_MDT_DATASET_PREFIX,
     LUSTRE_OST_DATASET_PREFIX,
     MKFS_LUSTRE_EXECUTABLE,
@@ -40,53 +36,6 @@ def pool_missing(mocker: MockerFixture) -> None:
 def pool_exists(mocker: MockerFixture) -> None:
     """Mock _pool_exists to return True."""
     mocker.patch("lustre_fs._pool_exists", return_value=True)
-
-
-class TestInit:
-    """init() tests."""
-
-    def test_successful_init(self, mocker: MockerFixture) -> None:
-        """Successful init() call."""
-        mock_ensure = mocker.patch("lustre_fs._ensure_lnet_tcp", autospec=True)
-        mock_persist = mocker.patch("lustre_fs._persist_lnet_config", autospec=True)
-        mocker.patch("lustre_fs._get_default_interface", return_value="eth0")
-
-        lustre_fs.init()
-
-        mock_ensure.assert_called_once_with("eth0")
-        mock_persist.assert_called_once()
-
-
-class TestGetNids:
-    """get_nids() tests."""
-
-    def test_success(self, mocker: MockerFixture, mock_run: MagicMock) -> None:
-        """Returns a list of NIDs from lctl output."""
-        mock_run.return_value.stdout = "10.0.0.5@tcp\n10.0.0.6@tcp\n"
-
-        assert lustre_fs.get_nids() == ["10.0.0.5@tcp", "10.0.0.6@tcp"]
-
-    def test_empty_output(self, mocker: MockerFixture, mock_run: MagicMock) -> None:
-        """Returns an empty list when no NIDs are configured."""
-        mock_run.return_value.stdout = ""
-
-        assert lustre_fs.get_nids() == []
-
-    def test_lctl_run_error(self, mocker: MockerFixture, mock_run: MagicMock) -> None:
-        """Lctl command fails."""
-        mock_run.side_effect = subprocess.CalledProcessError(1, LCTL_EXECUTABLE)
-
-        with pytest.raises(LustreFilesystemError) as excinfo:
-            lustre_fs.get_nids()
-        assert isinstance(excinfo.value.__cause__, subprocess.CalledProcessError)
-
-    def test_lctl_not_found(self, mocker: MockerFixture, mock_run: MagicMock) -> None:
-        """Lctl executable is not found."""
-        mock_run.side_effect = FileNotFoundError(1, "/bad/path/to/lctl")
-
-        with pytest.raises(LustreFilesystemError) as excinfo:
-            lustre_fs.get_nids()
-        assert isinstance(excinfo.value.__cause__, FileNotFoundError)
 
 
 class TestMgsMdsSetup:
@@ -158,60 +107,6 @@ class TestOssSetup:
         with pytest.raises(LustreFilesystemError) as excinfo:
             lustre_fs.oss_setup(self.FSNAME, "lustre/0", self.MGS_NID)
         assert isinstance(excinfo.value.__cause__, ValueError)
-
-
-class TestEnsureLnetTcp:
-    """_ensure_lnet_tcp() tests."""
-
-    def test_creates_when_missing(self, mocker: MockerFixture, mock_run: MagicMock) -> None:
-        """Adds interface to TCP network when it is not already present."""
-        mock_run.return_value.returncode = 1  # net show fails
-
-        lustre_fs._ensure_lnet_tcp("eth0")
-
-        assert mock_run.call_count == 2
-        add_call = mock_run.call_args_list[1]
-        assert add_call[0][0] == [LNETCTL_EXECUTABLE, "net", "add", "--net", "tcp", "--if", "eth0"]
-
-    def test_skips_when_exists(self, mocker: MockerFixture, mock_run: MagicMock) -> None:
-        """Skips adding the TCP network when it is already present."""
-        mock_run.return_value.returncode = 0
-        lustre_fs._ensure_lnet_tcp("eth0")
-        mock_run.assert_called_once()  # only net show, no net add
-
-    def test_lnetctl_failure(self, mocker: MockerFixture, mock_run: MagicMock) -> None:
-        """Lnetctl failure."""
-        mock_run.side_effect = subprocess.CalledProcessError(1, LNETCTL_EXECUTABLE)
-
-        with pytest.raises(LustreFilesystemError) as excinfo:
-            lustre_fs._ensure_lnet_tcp("eth0")
-        assert isinstance(excinfo.value.__cause__, subprocess.CalledProcessError)
-
-
-class TestPersistLnetConfig:
-    """_persist_lnet_config() tests."""
-
-    def test_successful_export(self, mocker: MockerFixture, tmp_path: Path) -> None:
-        """Exports the LNet configuration to a file with 0600 permissions."""
-        conf_path = tmp_path / "lnet.conf"
-        mocker.patch("lustre_fs.LUSTRE_LNET_CONF", conf_path)
-        mocker.patch("lustre_fs.subprocess.check_output", return_value="config data")
-
-        lustre_fs._persist_lnet_config()
-
-        assert conf_path.read_text() == "config data"
-        assert stat.S_IMODE(conf_path.stat().st_mode) == 0o600
-
-    def test_export_failure(self, mocker: MockerFixture) -> None:
-        """Lnetctl export failure."""
-        mocker.patch(
-            "lustre_fs.subprocess.check_output",
-            side_effect=subprocess.CalledProcessError(1, LNETCTL_EXECUTABLE),
-        )
-
-        with pytest.raises(LustreFilesystemError) as excinfo:
-            lustre_fs._persist_lnet_config()
-        assert isinstance(excinfo.value.__cause__, subprocess.CalledProcessError)
 
 
 class TestMgtMdtZpool:
@@ -439,48 +334,6 @@ class TestDetectDevices:
 
         assert len(devices) == 4
         mock_run.assert_not_called()
-
-
-class TestGetDefaultInterface:
-    """_get_default_interface() tests."""
-
-    def test_success(self, mocker: MockerFixture, mock_run: MagicMock) -> None:
-        """Successfully retrieves the default network interface."""
-        mock_run.return_value.stdout = json.dumps([{"dev": "eth0"}])
-
-        assert lustre_fs._get_default_interface() == "eth0"
-
-    def test_ip_run_error(self, mocker: MockerFixture, mock_run: MagicMock) -> None:
-        """Ip command fails."""
-        mock_run.side_effect = subprocess.CalledProcessError(1, "ip")
-
-        with pytest.raises(LustreFilesystemError) as excinfo:
-            lustre_fs._get_default_interface()
-        assert isinstance(excinfo.value.__cause__, subprocess.CalledProcessError)
-
-    def test_bad_json(self, mocker: MockerFixture, mock_run: MagicMock) -> None:
-        """Ip command returns invalid JSON."""
-        mock_run.return_value.stdout = "not json"
-
-        with pytest.raises(LustreFilesystemError) as excinfo:
-            lustre_fs._get_default_interface()
-        assert isinstance(excinfo.value.__cause__, json.JSONDecodeError)
-
-    def test_missing_json_data(self, mocker: MockerFixture, mock_run: MagicMock) -> None:
-        """Ip command returns empty JSON array."""
-        mock_run.return_value.stdout = json.dumps([])
-
-        with pytest.raises(LustreFilesystemError) as excinfo:
-            lustre_fs._get_default_interface()
-        assert isinstance(excinfo.value.__cause__, IndexError)
-
-    def test_missing_dev_key(self, mocker: MockerFixture, mock_run: MagicMock) -> None:
-        """Ip command returns JSON without 'dev' key."""
-        mock_run.return_value.stdout = json.dumps([{"not_dev": "eth0"}])
-
-        with pytest.raises(LustreFilesystemError) as excinfo:
-            lustre_fs._get_default_interface()
-        assert isinstance(excinfo.value.__cause__, KeyError)
 
 
 class TestPoolExists:

--- a/charms/lustre-server/tests/unit/test_lustre_peer.py
+++ b/charms/lustre-server/tests/unit/test_lustre_peer.py
@@ -10,10 +10,11 @@ import ops
 import pytest
 from constants import LUSTRE_FSNAME
 from errors import LustreFilesystemError
+from lustre_ops.errors import LNetError
 from pytest_mock import MockerFixture
 
 MGS_UNIT_NAME = "lustre/0"
-MGS_NID = "10.0.0.5@tcp"
+MGS_NIDS = ["10.0.0.5@tcp", "10.0.0.6@o2ib0"]
 OSS_UNIT_NAME = "lustre/1"
 
 
@@ -39,32 +40,32 @@ def mock_model_with_relation(
     return mock_model, rel
 
 
-class TestMgsNidPublished:
-    """mgs_nid_published() tests."""
+class TestMgsNidsPublished:
+    """mgs_nids_published() tests."""
 
     def test_leader_publishes_nid(
         self, mocker: MockerFixture, mock_model_with_relation: tuple[MagicMock, MagicMock]
     ) -> None:
-        """Leader unit publishes MGS NID to relation data."""
+        """Leader unit publishes MGS NIDs to relation data."""
         model, rel = mock_model_with_relation
         model.app.planned_units.return_value = 1
         model.unit.is_leader.return_value = True
         model.unit.name = MGS_UNIT_NAME
         rel.load.return_value = None
         mocker.patch("lustre_peer.lustre_fs.oss_setup")
-        mocker.patch("lustre_peer.lustre_fs.get_nids", return_value=[MGS_NID])
+        mocker.patch("lustre_peer.lnet.get_nids", return_value=MGS_NIDS)
 
         observer = lustre_peer.LustrePeerObserver(mocker.MagicMock())
-        result = observer.mgs_nid_published()
+        result = observer.mgs_nids_published()
 
-        assert result == MGS_NID
+        assert result == MGS_NIDS
         assert rel.save.call_count == 2
 
         unit_data = rel.save.call_args_list[0][0][0]
         app_data = rel.save.call_args_list[1][0][0]
 
         assert unit_data.ready is True
-        assert app_data.mgs_nid == MGS_NID
+        assert app_data.mgs_nids == MGS_NIDS
         assert app_data.mgs_unit_name == MGS_UNIT_NAME
 
     def test_non_leader_raises(self, mocker: MockerFixture, mock_model: MagicMock) -> None:
@@ -73,7 +74,7 @@ class TestMgsNidPublished:
 
         observer = lustre_peer.LustrePeerObserver(mocker.MagicMock())
         with pytest.raises(lustre_peer.LustrePeerError, match="Non-leader"):
-            observer.mgs_nid_published()
+            observer.mgs_nids_published()
 
     def test_get_nid_fails(
         self, mocker: MockerFixture, mock_model_with_relation: tuple[MagicMock, MagicMock]
@@ -85,27 +86,44 @@ class TestMgsNidPublished:
         rel.load.return_value = None
         mocker.patch("lustre_peer.lustre_fs.oss_setup")
         mocker.patch(
-            "lustre_peer.lustre_fs.get_nids",
-            side_effect=LustreFilesystemError("test get_nids failed"),
+            "lustre_peer.lnet.get_nids",
+            side_effect=LNetError("test get_nids failed"),
         )
 
         observer = lustre_peer.LustrePeerObserver(mocker.MagicMock())
         with pytest.raises(lustre_peer.LustrePeerError, match="Failed to determine MGS NID"):
-            observer.mgs_nid_published()
+            observer.mgs_nids_published()
+
+    def test_empty_nids(
+        self, mocker: MockerFixture, mock_model_with_relation: tuple[MagicMock, MagicMock]
+    ) -> None:
+        """Leader unit raises an error when no NIDs are configured."""
+        model, rel = mock_model_with_relation
+        model.unit.is_leader.return_value = True
+        model.unit.name = MGS_UNIT_NAME
+        rel.load.return_value = None
+        mocker.patch("lustre_peer.lustre_fs.oss_setup")
+        mocker.patch("lustre_peer.lnet.get_nids", return_value=[])
+
+        observer = lustre_peer.LustrePeerObserver(mocker.MagicMock())
+        with pytest.raises(
+            lustre_peer.LustrePeerError, match="No LNet NIDs configured on this unit"
+        ):
+            observer.mgs_nids_published()
 
     def test_nid_already_published(
         self, mocker: MockerFixture, mock_model_with_relation: tuple[MagicMock, MagicMock]
     ) -> None:
-        """Leader unit does not overwrite existing MGS NID in relation data."""
+        """Leader unit does not overwrite existing MGS NIDs in relation data."""
         model, rel = mock_model_with_relation
         model.unit.is_leader.return_value = True
-        existing = lustre_peer.LustrePeerAppData(mgs_nid=MGS_NID, mgs_unit_name=MGS_UNIT_NAME)
+        existing = lustre_peer.LustrePeerAppData(mgs_nids=MGS_NIDS, mgs_unit_name=MGS_UNIT_NAME)
         rel.load.return_value = existing
 
         observer = lustre_peer.LustrePeerObserver(mocker.MagicMock())
-        result = observer.mgs_nid_published()
+        result = observer.mgs_nids_published()
 
-        assert result == MGS_NID
+        assert result == MGS_NIDS
         rel.save.assert_not_called()
 
 
@@ -120,7 +138,7 @@ class TestOnRelationChanged:
         mock_model.app.planned_units.return_value = 1
         mock_model.unit.name = OSS_UNIT_NAME
 
-        app_data = lustre_peer.LustrePeerAppData(mgs_nid=MGS_NID, mgs_unit_name=MGS_UNIT_NAME)
+        app_data = lustre_peer.LustrePeerAppData(mgs_nids=MGS_NIDS, mgs_unit_name=MGS_UNIT_NAME)
         unit_data = lustre_peer.LustrePeerUnitData()
         mocker.patch("lustre_peer.LustrePeerObserver.get_app_data", return_value=app_data)
         mocker.patch("lustre_peer.LustrePeerObserver.get_unit_data", return_value=unit_data)
@@ -142,7 +160,7 @@ class TestOnRelationChanged:
         observer = lustre_peer.LustrePeerObserver(mocker.MagicMock())
         observer._on_relation_changed(mocker.MagicMock())
 
-        mock_oss.assert_called_once_with(LUSTRE_FSNAME, OSS_UNIT_NAME, MGS_NID)
+        mock_oss.assert_called_once_with(LUSTRE_FSNAME, OSS_UNIT_NAME, MGS_NIDS)
         assert mock_model.unit.status == expected_status
 
     def test_app_data_error(self, mocker: MockerFixture, mock_model: MagicMock) -> None:
@@ -172,7 +190,7 @@ class TestOnRelationChanged:
         """MGS unit does not attempt to set up OSS."""
         mock_model.app.planned_units.return_value = 1
         mock_model.unit.name = MGS_UNIT_NAME
-        app_data = lustre_peer.LustrePeerAppData(mgs_nid=MGS_NID, mgs_unit_name=MGS_UNIT_NAME)
+        app_data = lustre_peer.LustrePeerAppData(mgs_nids=MGS_NIDS, mgs_unit_name=MGS_UNIT_NAME)
         mocker.patch("lustre_peer.LustrePeerObserver.get_app_data", return_value=app_data)
         mock_oss = mocker.patch("lustre_peer.lustre_fs.oss_setup", autospec=True)
 
@@ -271,9 +289,9 @@ class TestTryPublishFilesystemInfo:
 
         charm = mocker.MagicMock()
         observer = lustre_peer.LustrePeerObserver(charm)
-        observer._try_publish_filesystem_info(MGS_NID, LUSTRE_FSNAME)
+        observer._try_publish_filesystem_info(MGS_NIDS, LUSTRE_FSNAME)
 
         charm.filesystem.set_info.assert_called_once()
         args, _ = charm.filesystem.set_info.call_args
-        assert args[0].mgs_ids == [MGS_NID]
+        assert args[0].mgs_ids == MGS_NIDS
         assert args[0].fs_name == LUSTRE_FSNAME

--- a/charms/lustre-server/tests/unit/test_lustre_peer.py
+++ b/charms/lustre-server/tests/unit/test_lustre_peer.py
@@ -209,7 +209,9 @@ class TestOnRelationChanged:
         observer = lustre_peer.LustrePeerObserver(mocker.MagicMock())
         observer._on_relation_changed(mocker.MagicMock())
 
-        assert model.unit.status == ops.BlockedStatus(lustre_peer.CharmStatuses.FAILED_OSS_SETUP)
+        assert model.unit.status == ops.BlockedStatus(
+            lustre_peer._LustrePeerStatus.FAILED_OSS_SETUP
+        )
 
     def test_set_unit_ready_failure(
         self, mocker: MockerFixture, oss_unit: tuple[MagicMock, MagicMock]
@@ -225,7 +227,7 @@ class TestOnRelationChanged:
         observer._on_relation_changed(mocker.MagicMock())
 
         assert model.unit.status == ops.BlockedStatus(
-            lustre_peer.CharmStatuses.FAILED_SET_UNIT_READY
+            lustre_peer._LustrePeerStatus.FAILED_SET_UNIT_READY
         )
 
     def test_publish_filesystem_info_failure(
@@ -244,7 +246,7 @@ class TestOnRelationChanged:
         observer._on_relation_changed(mocker.MagicMock())
 
         assert model.unit.status == ops.BlockedStatus(
-            lustre_peer.CharmStatuses.FAILED_PUBLISH_FILESYSTEM_INFO
+            lustre_peer._LustrePeerStatus.FAILED_PUBLISH_FILESYSTEM_INFO
         )
 
 

--- a/charms/lustre-server/tests/unit/test_lustre_peer.py
+++ b/charms/lustre-server/tests/unit/test_lustre_peer.py
@@ -130,7 +130,7 @@ class TestMgsNidsPublished:
 class TestOnRelationChanged:
     """_on_relation_changed() tests."""
 
-    @pytest.fixture
+    @pytest.fixture(scope="function")
     def oss_unit(
         self, mocker: MockerFixture, mock_model: MagicMock
     ) -> tuple[MagicMock, MagicMock]:

--- a/charms/lustre-server/tests/unit/test_state.py
+++ b/charms/lustre-server/tests/unit/test_state.py
@@ -95,12 +95,12 @@ class TestCommonStatus:
     def test_all_pass(self, mocker: MockerFixture) -> None:
         """All common checks pass, no status change."""
         mocker.patch("state._kernel_modules_check")
-        data = LustrePeerAppData(mgs_unit_name="lustre/0", mgs_nid="10.0.0.5@tcp")
+        data = LustrePeerAppData(mgs_unit_name="lustre/0", mgs_nids=["10.0.0.5@tcp"])
         assert state._common_check(data) is None
 
     def test_peer_data_missing(self) -> None:
         """Peer data is missing."""
-        data = LustrePeerAppData(mgs_unit_name=None, mgs_nid=None)
+        data = LustrePeerAppData(mgs_unit_name=None, mgs_nids=[])
 
         with pytest.raises(LustreStateError) as e:
             state._common_check(data)
@@ -110,7 +110,7 @@ class TestCommonStatus:
         """One of the required modules is missing."""
         expected_status = ops.BlockedStatus("test modules missing status")
         mocker.patch("state._kernel_modules_check", side_effect=LustreStateError(expected_status))
-        data = LustrePeerAppData(mgs_unit_name="lustre/0", mgs_nid="10.0.0.5@tcp")
+        data = LustrePeerAppData(mgs_unit_name="lustre/0", mgs_nids=["10.0.0.5@tcp"])
 
         with pytest.raises(LustreStateError) as e:
             state._common_check(data)
@@ -175,7 +175,7 @@ class TestCheckLustre:
         """Mock charm with unit and peer data."""
         charm = mocker.MagicMock()
         charm.unit.status = ops.ActiveStatus()
-        data = LustrePeerAppData(mgs_unit_name="lustre/0", mgs_nid="10.0.0.5@tcp")
+        data = LustrePeerAppData(mgs_unit_name="lustre/0", mgs_nids=["10.0.0.5@tcp"])
         charm.peers.get_app_data.return_value = data
         return charm
 

--- a/charms/lustre-server/tests/unit/test_state.py
+++ b/charms/lustre-server/tests/unit/test_state.py
@@ -170,7 +170,7 @@ class TestOssStatus:
 class TestCheckLustre:
     """Tests for top-level check_lustre."""
 
-    @pytest.fixture
+    @pytest.fixture(scope="function")
     def mock_charm(self, mocker: MockerFixture) -> MagicMock:
         """Mock charm with unit and peer data."""
         charm = mocker.MagicMock()
@@ -179,21 +179,21 @@ class TestCheckLustre:
         charm.peers.get_app_data.return_value = data
         return charm
 
-    @pytest.fixture
+    @pytest.fixture(scope="function")
     def mgs_mds_unit(self, mocker: MockerFixture, mock_charm: MagicMock) -> MagicMock:
         """Mock charm configured as the MGS+MDS unit with common checks passing."""
         mock_charm.model.unit.name = "lustre/0"
         mocker.patch("state._common_check", return_value=None)
         return mock_charm
 
-    @pytest.fixture
+    @pytest.fixture(scope="function")
     def oss_unit(self, mocker: MockerFixture, mock_charm: MagicMock) -> MagicMock:
         """Mock charm configured as an OSS unit with common checks passing."""
         mock_charm.model.unit.name = "lustre/1"
         mocker.patch("state._common_check", return_value=None)
         return mock_charm
 
-    @pytest.fixture
+    @pytest.fixture(scope="function")
     def existing_blocked(self, mock_charm: MagicMock) -> ops.BlockedStatus:
         """Set mock charm to an existing BlockedStatus and return that status."""
         existing = ops.BlockedStatus("existing error")

--- a/internal/lustre-ops/pyproject.toml
+++ b/internal/lustre-ops/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "lustre-ops"
 version = "0.0.1"
-requires-python = "==3.12.*"
+requires-python = "==3.14.*"
 dependencies = ["charmlibs-apt", "pydantic", "pyyaml"]
 
 [build-system]

--- a/internal/lustre-ops/pyproject.toml
+++ b/internal/lustre-ops/pyproject.toml
@@ -1,0 +1,12 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details
+
+[project]
+name = "lustre-ops"
+version = "0.0.1"
+requires-python = "==3.12.*"
+dependencies = ["charmlibs-apt", "pydantic", "pyyaml"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/internal/lustre-ops/src/lustre_ops/__init__.py
+++ b/internal/lustre-ops/src/lustre_ops/__init__.py
@@ -1,0 +1,8 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details
+
+"""Shared Lustre operations for the filesystem charms."""
+
+from lustre_ops import errors, lnet, ppa
+
+__all__ = ["errors", "lnet", "ppa"]

--- a/internal/lustre-ops/src/lustre_ops/constants.py
+++ b/internal/lustre-ops/src/lustre_ops/constants.py
@@ -1,0 +1,47 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details
+
+"""Constants used by the `lustre_ops` package."""
+
+from pathlib import Path
+
+LUSTRE_REPOSITORY_KEY = """-----BEGIN PGP PUBLIC KEY BLOCK-----
+Comment: Hostname:
+Version: Hockeypuck 2.2
+
+xsFNBGTuZb8BEACtJ1CnZe6/hv84DceHv+a54y3Pqq0gqED0xhTKnbj/E2ByJpmT
+NlDNkpeITwPAAN1e3824Me76Qn31RkogTMoPJ2o2XfG253RXd67MPxYhfKTJcnM3
+CEkmeI4u2Lynh3O6RQ08nAFS2AGTeFVFH2GPNWrfOsGZW03Jas85TZ0k7LXVHiBs
+W6qonbsFJhshvwC3SryG4XYT+z/+35x5fus4rPtMrrEOD65hij7EtQNaE8owuAju
+Kcd0m2b+crMXNcllWFWmYMV0VjksQvYD7jwGrWeKs+EeHgU8ZuqaIP4pYHvoQjag
+umqnH9Qsaq5NAXiuAIAGDIIV4RdAfQIR4opGaVgIFJdvoSwYe3oh2JlrLPBlyxyY
+dayDifd3X8jxq6/oAuyH1h5K/QLs46jLSR8fUbG98SCHlRmvozTuWGk+e07ALtGe
+sGv78ToHKwoM2buXaTTHMwYwu7Rx8LZ4bZPHdersN1VW/m9yn1n5hMzwbFKy2s6/
+D4Q2ZBsqlN+5aW2q0IUmO+m0GhcdaDv8U7RVto1cWWPr50HhiCi7Yvei1qZiD9jq
+57oYZVqTUNCTPxi6NeTOdEc+YqNynWNArx4PHh38LT0bqKtlZCGHNfoAJLPVYhbB
+b2AHj9edYtHU9AAFSIy+HstET6P0UDxy02IeyE2yxoUBqdlXyv6FL44E+wARAQAB
+zRxMYXVuY2hwYWQgUFBBIGZvciBVYnVudHUgSFBDwsGOBBMBCgA4FiEErocSHcPk
+oLD4H/Aj9tDF1ca+s3sFAmTuZb8CGwMFCwkIBwIGFQoJCAsCBBYCAwECHgECF4AA
+CgkQ9tDF1ca+s3sz3w//RNawsgydrutcbKf0yphDhzWS53wgfrs2KF1KgB0u/H+u
+6Kn2C6jrVM0vuY4NKpbEPCduOj21pTCepL6PoCLv++tICOLVok5wY7Zn3WQFq0js
+Iy1wO5t3kA1cTD/05v/qQVBGZ2j4DsJo33iMcQS5AjHvSr0nu7XSvDDEE3cQE55D
+87vL7lgGjuTOikPh5FpCoS1gpemBfwm2Lbm4P8vGOA4/witRjGgfC1fv1idUnZLM
+TbGrDlhVie8pX2kgB6yTYbJ3P3kpC1ZPpXSRWO/cQ8xoYpLBTXOOtqwZZUnxyzHh
+gM+hv42vPTOnCo+apD97/VArsp59pDqEVoAtMTk72fdBqR+BB77g2hBkKESgQIEq
+EiE1/TOISioMkE0AuUdaJ2ebyQXugSHHuBaqbEC47v8t5DVN5Qr9OriuzCuSDNFn
+6SBHpahN9ZNi9w0A/Yh1+lFfpkVw2t04Q2LNuupqOpW+h3/62AeUqjUIAIrmfeML
+IDRE2VdquYdIXKuhNvfpJYGdyvx/wAbiAeBWg0uPSepwTfTG59VPQmj0FtalkMnN
+ya2212K5q68O5eXOfCnGeMvqIXxqzpdukxSZnLkgk40uFJnJVESd/CxHquqHPUDE
+fy6i2AnB3kUI27D4HY2YSlXLSRbjiSxTfVwNCzDsIh7Czefsm6ITK2+cVWs0hNQ=
+=cs1s
+-----END PGP PUBLIC KEY BLOCK-----
+"""
+LUSTRE_REPOSITORY_URI = "https://ppa.launchpadcontent.net/ubuntu-hpc/lustre-2.17/ubuntu/"
+LUSTRE_LNET_CONF = Path("/etc/lnet.conf")
+
+IP_EXECUTABLE = "/usr/sbin/ip"
+LCTL_EXECUTABLE = "/usr/sbin/lctl"
+LNETCTL_EXECUTABLE = "/usr/sbin/lnetctl"
+RDMA_EXECUTABLE = "/usr/bin/rdma"
+
+SYS_CLASS_NET = Path("/sys/class/net")

--- a/internal/lustre-ops/src/lustre_ops/errors.py
+++ b/internal/lustre-ops/src/lustre_ops/errors.py
@@ -12,5 +12,45 @@ class LNetError(LustreOpsError):
     """Raised when an LNet operation fails."""
 
 
-class RepositoryError(LustreOpsError):
+class LNetAddInterfaceError(LNetError):
+    """Raised when an LNet interface addition operation fails."""
+
+
+class LNetAddNetworkError(LNetError):
+    """Raised when an LNet network addition operation fails."""
+
+
+class LNetAutodetectError(LNetError):
+    """Raised when an LNet auto-detection operation fails."""
+
+
+class LNetConfigExportError(LNetError):
+    """Raised when an LNet configuration export operation fails."""
+
+
+class LNetParseError(LNetError):
+    """Raised when an LNet parsing operation fails."""
+
+
+class LNetRemoveInterfaceError(LNetError):
+    """Raised when an LNet interface removal operation fails."""
+
+
+class LNetQueryError(LNetError):
+    """Raised when an LNet query operation fails."""
+
+
+class RepositoryError(LNetError):
     """Raised when a Lustre package repository operation fails."""
+
+
+class RepositoryCodenameError(RepositoryError):
+    """Raised when a Lustre package repository codename determination fails."""
+
+
+class RepositoryGPGKeyError(RepositoryError):
+    """Raised when a Lustre package repository GPG key operation fails."""
+
+
+class RepositorySyncError(RepositoryError):
+    """Raised when a Lustre package repository synchronization operation fails."""

--- a/internal/lustre-ops/src/lustre_ops/errors.py
+++ b/internal/lustre-ops/src/lustre_ops/errors.py
@@ -1,0 +1,16 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details
+
+"""Exceptions raised by the `lustre_ops` package."""
+
+
+class LustreOpsError(Exception):
+    """Base class for errors raised by the `lustre_ops` package."""
+
+
+class LNetError(LustreOpsError):
+    """Raised when an LNet operation fails."""
+
+
+class RepositoryError(LustreOpsError):
+    """Raised when a Lustre package repository operation fails."""

--- a/internal/lustre-ops/src/lustre_ops/lnet.py
+++ b/internal/lustre-ops/src/lustre_ops/lnet.py
@@ -18,7 +18,15 @@ from lustre_ops.constants import (
     LNETCTL_EXECUTABLE,
     LUSTRE_LNET_CONF,
 )
-from lustre_ops.errors import LNetError
+from lustre_ops.errors import (
+    LNetAddInterfaceError,
+    LNetAddNetworkError,
+    LNetAutodetectError,
+    LNetConfigExportError,
+    LNetParseError,
+    LNetQueryError,
+    LNetRemoveInterfaceError,
+)
 from lustre_ops.lnet_detection import detect_networks
 
 _logger = logging.getLogger(__name__)
@@ -58,14 +66,14 @@ def init(networks: dict[str, list[str]] | None = None) -> None:
         If ``None``, networks are auto-detected.
 
     Raises:
-        LNetError: If any LNet operation fails or if auto-detection finds no usable network
-        interfaces.
+        LNetAutodetectError: If auto-detection finds no usable network interfaces.
+        LNetError: If any other LNet operation fails.
     """
     if networks is None:
         networks = detect_networks()
         _logger.info("LNet networks determined by auto-detection: %s", networks)
         if not networks:
-            raise LNetError("Auto-detection found no usable network interfaces")
+            raise LNetAutodetectError("Auto-detection found no usable network interfaces")
 
     _ensure_networks(networks)
     _persist_lnet_config()
@@ -79,14 +87,14 @@ def get_nids() -> list[str]:
         Empty if no NIDs are configured.
 
     Raises:
-        LNetError: If querying the NIDs fails.
+        LNetQueryError: If querying the NIDs fails.
     """
     try:
         result = subprocess.run(
             [LCTL_EXECUTABLE, "list_nids"], capture_output=True, text=True, check=True
         )
     except (subprocess.CalledProcessError, FileNotFoundError) as e:
-        raise LNetError("Failed to query Lustre NIDs") from e
+        raise LNetQueryError("Failed to query Lustre NIDs") from e
 
     return [line.strip() for line in result.stdout.splitlines() if line.strip()]
 
@@ -113,7 +121,7 @@ def parse_network_config(spec: str) -> dict[str, list[str]] | None:
         is provided.
 
     Raises:
-        LNetError: If the specification is malformed.
+        LNetParseError: If the specification is malformed.
     """
     spec = spec.strip()
     if not spec:
@@ -125,12 +133,12 @@ def parse_network_config(spec: str) -> dict[str, list[str]] | None:
         if not token:
             continue
         if "=" not in token:
-            raise LNetError(f"Invalid LNet network specification `{token}`")
+            raise LNetParseError(f"Invalid LNet network specification `{token}`")
 
         name, interfaces_str = token.split("=", 1)
         name = name.strip()
         if not name:
-            raise LNetError(f"Empty network name in `{token}`")
+            raise LNetParseError(f"Empty network name in `{token}`")
 
         # Special case of index 0 network must be handled.
         # LNet indexes from 0 but does not require the trailing 0 for the first net.
@@ -148,10 +156,10 @@ def parse_network_config(spec: str) -> dict[str, list[str]] | None:
 
         interfaces = [s.strip() for s in interfaces_str.split(",") if s.strip()]
         if not interfaces:
-            raise LNetError(f"No interfaces specified for network `{token}`")
+            raise LNetParseError(f"No interfaces specified for network `{token}`")
 
         if name in networks:
-            raise LNetError(f"Duplicate LNet network `{name}`")
+            raise LNetParseError(f"Duplicate LNet network `{name}`")
         networks[name] = interfaces
 
     return networks
@@ -165,7 +173,7 @@ def _add_interfaces(net: str, interfaces: set[str]) -> None:
         interfaces: The interfaces to add.
 
     Raises:
-        LNetError: If adding interfaces fails.
+        LNetAddInterfaceError: If adding interfaces fails.
     """
     cmd = [LNETCTL_EXECUTABLE, "interface", "add", "--net", net]
     for iface in sorted(interfaces):  # sort to ensure deterministic interface order
@@ -174,7 +182,9 @@ def _add_interfaces(net: str, interfaces: set[str]) -> None:
     try:
         subprocess.run(cmd, check=True)
     except (subprocess.CalledProcessError, FileNotFoundError) as e:
-        raise LNetError(f"Failed to add interfaces {interfaces} to LNet network {net}") from e
+        raise LNetAddInterfaceError(
+            f"Failed to add interfaces {interfaces} to LNet network {net}"
+        ) from e
 
 
 def _add_network(name: str, interfaces: list[str]) -> None:
@@ -185,7 +195,7 @@ def _add_network(name: str, interfaces: list[str]) -> None:
         interfaces: The interfaces to bind to this network.
 
     Raises:
-        LNetError: If adding the network fails.
+        LNetAddNetworkError: If adding the network fails.
     """
     cmd = [LNETCTL_EXECUTABLE, "net", "add", "--net", name]
     for iface in interfaces:
@@ -193,7 +203,7 @@ def _add_network(name: str, interfaces: list[str]) -> None:
     try:
         subprocess.run(cmd, check=True)
     except (subprocess.CalledProcessError, FileNotFoundError) as e:
-        raise LNetError(f"Failed to add LNet network {name}") from e
+        raise LNetAddNetworkError(f"Failed to add LNet network {name}") from e
 
 
 def _ensure_networks(networks: dict[str, list[str]]) -> None:
@@ -208,7 +218,10 @@ def _ensure_networks(networks: dict[str, list[str]]) -> None:
         ``{"tcp": ["eth0"], "o2ib": ["ib0", "ib1"]}``.
 
     Raises:
-        LNetError: If any LNet operation fails.
+        LNetAddNetworkError: If adding a network fails.
+        LNetAddInterfaceError: If adding interfaces fails.
+        LNetQueryError: If querying the existing LNet networks fails.
+        LNetRemoveInterfaceError: If removing interfaces fails.
     """
     try:
         result = subprocess.run(
@@ -218,7 +231,7 @@ def _ensure_networks(networks: dict[str, list[str]]) -> None:
             check=True,
         )
     except (subprocess.CalledProcessError, FileNotFoundError) as e:
-        raise LNetError("Failed to query LNet networks") from e
+        raise LNetQueryError("Failed to query LNet networks") from e
 
     # TODO: Address potential TOCTOU race. State of LNet networks may change between above query and
     # the add/remove operations below. This will only occur if the networks are being modified by
@@ -251,7 +264,7 @@ def _persist_lnet_config() -> None:
     """Export the current LNet configuration to the disk.
 
     Raises:
-        LNetError: If persisting the LNet configuration fails.
+        LNetConfigExportError: If persisting the LNet configuration fails.
     """
     try:
         result = subprocess.run(
@@ -266,7 +279,7 @@ def _persist_lnet_config() -> None:
         tmp.write_text(result)
         tmp.replace(LUSTRE_LNET_CONF)
     except (subprocess.CalledProcessError, FileNotFoundError, OSError) as e:
-        raise LNetError("Failed to write LNet configuration data") from e
+        raise LNetConfigExportError("Failed to write LNet configuration data") from e
 
 
 def _parse_networks(show_output: str) -> dict[str, list[str]]:
@@ -279,7 +292,7 @@ def _parse_networks(show_output: str) -> dict[str, list[str]]:
         A mapping from LNet network name to its interfaces.
 
     Raises:
-        LNetError: If the given string cannot be parsed.
+        LNetParseError: If the given string cannot be parsed.
     """
     # Sample `lnetctl net show`:
     #
@@ -310,15 +323,15 @@ def _parse_networks(show_output: str) -> dict[str, list[str]]:
     try:
         data = yaml.safe_load(show_output)
     except yaml.YAMLError as e:
-        raise LNetError("Failed to parse LNet network output") from e
+        raise LNetParseError("Failed to parse LNet network output") from e
 
     if data is None:
-        raise LNetError("Empty LNet network output")
+        raise LNetParseError("Empty LNet network output")
 
     try:
         parsed = _NetShowOutput.model_validate(data)
     except ValidationError as e:
-        raise LNetError(f"Failed to validate LNet network output: {data}") from e
+        raise LNetParseError(f"Failed to validate LNet network output: {data}") from e
 
     if not parsed.net:
         # TODO: Confirm if this should be an error. Empty "net" indicates no networks configured,
@@ -344,7 +357,7 @@ def _remove_interfaces(net: str, interfaces: set[str]) -> None:
         interfaces: The interfaces to remove.
 
     Raises:
-        LNetError: If removing the interfaces fails.
+        LNetRemoveInterfaceError: If removing the interfaces fails.
     """
     cmd = [LNETCTL_EXECUTABLE, "interface", "del", "--net", net]
     for iface in interfaces:
@@ -353,4 +366,6 @@ def _remove_interfaces(net: str, interfaces: set[str]) -> None:
     try:
         subprocess.run(cmd, check=True)
     except (subprocess.CalledProcessError, FileNotFoundError) as e:
-        raise LNetError(f"Failed to remove interfaces {interfaces} from LNet network {net}") from e
+        raise LNetRemoveInterfaceError(
+            f"Failed to remove interfaces {interfaces} from LNet network {net}"
+        ) from e

--- a/internal/lustre-ops/src/lustre_ops/lnet.py
+++ b/internal/lustre-ops/src/lustre_ops/lnet.py
@@ -1,0 +1,356 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details
+
+"""LNet operations shared by the Lustre server and filesystem client charms.
+
+Supports TCP (`tcp`) and InfiniBand (`o2ib`) LNDs, multiple networks, and
+multi-rail (multiple interfaces bound to a single LNet network).
+"""
+
+import logging
+import subprocess
+
+import yaml
+from pydantic import BaseModel, Field, ValidationError
+
+from lustre_ops.constants import (
+    LCTL_EXECUTABLE,
+    LNETCTL_EXECUTABLE,
+    LUSTRE_LNET_CONF,
+)
+from lustre_ops.errors import LNetError
+from lustre_ops.lnet_detection import detect_networks
+
+_logger = logging.getLogger(__name__)
+
+
+class _LocalNI(BaseModel):
+    """A local Network Interface entry from ``lnetctl net show`` output."""
+
+    interfaces: dict[int, str] = Field(default_factory=dict)
+
+
+class _Net(BaseModel):
+    """A network entry from ``lnetctl net show`` output."""
+
+    net_type: str = Field(alias="net type")
+    local_nis: list[_LocalNI] = Field(alias="local NI(s)", min_length=1)
+
+
+class _NetShowOutput(BaseModel):
+    """Parsed ``lnetctl net show`` output."""
+
+    net: list[_Net] | None = None
+
+
+def init(networks: dict[str, list[str]] | None = None) -> None:
+    """Initialize LNet on this unit. Idempotent.
+
+    When ``networks`` is ``None``, LNet networks are auto-configured based on available interfaces
+    on the host: a ``tcp`` network is configured on the default-route interface and an ``o2ib``
+    network is configured on all detected RDMA netdevs.
+
+    When ``networks`` is provided, it is used as-is, overriding auto-detection.
+
+    Args:
+        networks: Dictionary of LNet networks and interfaces to configure. Example:
+        ``{"tcp": ["eth0"], "o2ib": ["ib0", "ib1"]}``.
+        If ``None``, networks are auto-detected.
+
+    Raises:
+        LNetError: If any LNet operation fails or if auto-detection finds no usable network
+        interfaces.
+    """
+    if networks is None:
+        networks = detect_networks()
+        _logger.info("LNet networks determined by auto-detection: %s", networks)
+        if not networks:
+            raise LNetError("Auto-detection found no usable network interfaces")
+
+    _ensure_networks(networks)
+    _persist_lnet_config()
+
+
+def get_nids() -> list[str]:
+    """Return all Lustre NIDs configured on this unit.
+
+    Returns:
+        A list of NID strings in format <address>@<LND protocol><lnd#>. Example: ["10.0.0.5@tcp"].
+        Empty if no NIDs are configured.
+
+    Raises:
+        LNetError: If querying the NIDs fails.
+    """
+    try:
+        result = subprocess.run(
+            [LCTL_EXECUTABLE, "list_nids"], capture_output=True, text=True, check=True
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError) as e:
+        raise LNetError("Failed to query Lustre NIDs") from e
+
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def parse_network_config(spec: str) -> dict[str, list[str]] | None:
+    """Parse an operator-supplied LNet network specification string.
+
+    The string is a semicolon-separated list of networks of the form:
+    ``<name>=<iface>[,<iface>...]``, where ``<name>`` is the full LNet network name
+    (e.g. ``tcp``, ``o2ib1``). Multiple interfaces on one network constitute
+    multi-rail. Examples:
+
+        tcp=eth0
+        o2ib=ib0,ib1
+        tcp=eth0; o2ib=ib0,ib1
+        tcp=eth0; tcp1=eth1;
+        o2ib1=ib2
+
+    Args:
+        spec: The specification string.
+
+    Returns:
+        A mapping from LNet network name to its interfaces. `None` if an empty/whitespace-only spec
+        is provided.
+
+    Raises:
+        LNetError: If the specification is malformed.
+    """
+    spec = spec.strip()
+    if not spec:
+        return None
+
+    networks: dict[str, list[str]] = {}
+    for token in spec.split(";"):
+        token = token.strip()
+        if not token:
+            continue
+        if "=" not in token:
+            raise LNetError(f"Invalid LNet network specification `{token}`")
+
+        name, interfaces_str = token.split("=", 1)
+        name = name.strip()
+        if not name:
+            raise LNetError(f"Empty network name in `{token}`")
+
+        # Special case of index 0 network must be handled.
+        # LNet indexes from 0 but does not require the trailing 0 for the first net.
+        # Example:
+        #   `lnetctl net add --net tcp --if eth0`
+        # and:
+        #   `lnetctl net add --net tcp0 --if eth0`
+        # are equivalent, and `lnetctl net show` always renders the NIDs as `@tcp` (no trailing 0).
+        #
+        # Check for a trailing 0 here and remove it to ensure configurations like `tcp=eth0` and
+        # `tcp0=eth0` are treated equivalently. Second-to-last character is also checked to avoid
+        # removing a trailing 0 from a network name such as `o2ib10`.
+        if len(name) > 1 and name[-1] == "0" and not name[-2].isdigit():
+            name = name[:-1]
+
+        interfaces = [s.strip() for s in interfaces_str.split(",") if s.strip()]
+        if not interfaces:
+            raise LNetError(f"No interfaces specified for network `{token}`")
+
+        if name in networks:
+            raise LNetError(f"Duplicate LNet network `{name}`")
+        networks[name] = interfaces
+
+    return networks
+
+
+def _add_interfaces(net: str, interfaces: set[str]) -> None:
+    """Add interfaces to an existing LNet network.
+
+    Args:
+        net: The LNet network name (e.g. ``tcp0``).
+        interfaces: The interfaces to add.
+
+    Raises:
+        LNetError: If adding interfaces fails.
+    """
+    cmd = [LNETCTL_EXECUTABLE, "interface", "add", "--net", net]
+    for iface in sorted(interfaces):  # sort to ensure deterministic interface order
+        cmd += ["--if", iface]
+
+    try:
+        subprocess.run(cmd, check=True)
+    except (subprocess.CalledProcessError, FileNotFoundError) as e:
+        raise LNetError(f"Failed to add interfaces {interfaces} to LNet network {net}") from e
+
+
+def _add_network(name: str, interfaces: list[str]) -> None:
+    """Add a new LNet network with all given interfaces.
+
+    Args:
+        name: The LNet network name (e.g. ``tcp0``, ``o2ib1``).
+        interfaces: The interfaces to bind to this network.
+
+    Raises:
+        LNetError: If adding the network fails.
+    """
+    cmd = [LNETCTL_EXECUTABLE, "net", "add", "--net", name]
+    for iface in interfaces:
+        cmd += ["--if", iface]
+    try:
+        subprocess.run(cmd, check=True)
+    except (subprocess.CalledProcessError, FileNotFoundError) as e:
+        raise LNetError(f"Failed to add LNet network {name}") from e
+
+
+def _ensure_networks(networks: dict[str, list[str]]) -> None:
+    """Ensure each of the given LNet networks is configured as specified. Idempotent.
+
+    If a given network does not exist, it is created. If it already exists, missing interfaces are
+    added and stale interfaces are removed. Networks that exist on the host but are absent from
+    ``networks`` are not removed.
+
+    Args:
+        networks: Dictionary of LNet networks and interfaces to configure. Example:
+        ``{"tcp": ["eth0"], "o2ib": ["ib0", "ib1"]}``.
+
+    Raises:
+        LNetError: If any LNet operation fails.
+    """
+    try:
+        result = subprocess.run(
+            [LNETCTL_EXECUTABLE, "net", "show"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError) as e:
+        raise LNetError("Failed to query LNet networks") from e
+
+    # TODO: Address potential TOCTOU race. State of LNet networks may change between above query and
+    # the add/remove operations below. This will only occur if the networks are being modified by
+    # another process outside of charm control (unlikely).
+
+    existing_networks = _parse_networks(result.stdout)
+    for name, interfaces in networks.items():
+        if name not in existing_networks:
+            # Network is missing: add it and all interfaces.
+            _add_network(name, interfaces)
+            _logger.debug("added LNet network %s with interfaces %s", name, interfaces)
+            continue
+
+        # Network exists: reconcile interfaces.
+        desired_interfaces = set(interfaces)
+        bound_interfaces = set(existing_networks.get(name, []))
+
+        to_add = desired_interfaces - bound_interfaces
+        if to_add:
+            _add_interfaces(name, to_add)
+            _logger.debug("added interfaces %s to LNet network %s", to_add, name)
+
+        to_remove = bound_interfaces - desired_interfaces
+        if to_remove:
+            _remove_interfaces(name, to_remove)
+            _logger.debug("removed interfaces %s from LNet network %s", to_remove, name)
+
+
+def _persist_lnet_config() -> None:
+    """Export the current LNet configuration to the disk.
+
+    Raises:
+        LNetError: If persisting the LNet configuration fails.
+    """
+    try:
+        result = subprocess.run(
+            [LNETCTL_EXECUTABLE, "export", "--backup"], text=True, check=True, capture_output=True
+        ).stdout
+
+        # Write to temp file then atomically replace existing config. Avoids leaving partial config
+        # file if write process is interrupted.
+        tmp = LUSTRE_LNET_CONF.with_name(f".{LUSTRE_LNET_CONF.name}.tmp")
+        tmp.unlink(missing_ok=True)  # Clean up any failed previous attempt.
+        tmp.touch(mode=0o600)
+        tmp.write_text(result)
+        tmp.replace(LUSTRE_LNET_CONF)
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError) as e:
+        raise LNetError("Failed to write LNet configuration data") from e
+
+
+def _parse_networks(show_output: str) -> dict[str, list[str]]:
+    """Parse all networks and their bound interfaces from ``lnetctl net show`` output.
+
+    Args:
+        show_output: The raw stdout of ``lnetctl net show``.
+
+    Returns:
+        A mapping from LNet network name to its interfaces.
+
+    Raises:
+        LNetError: If the given string cannot be parsed.
+    """
+    # Sample `lnetctl net show`:
+    #
+    # net:
+    # -     net type: lo
+    #       local NI(s):
+    #       -     nid: 0@lo
+    #             status: up
+    # -     net type: o2ib
+    #       local NI(s):
+    #       -     nid: 10.0.0.10@o2ib
+    #             status: up
+    #             interfaces:
+    #                   0: enp6s0
+    #       -     nid: 10.0.0.11@o2ib
+    #             status: up
+    #             interfaces:
+    #                   0: enp7s0
+    # -     net type: tcp
+    #       local NI(s):
+    #       -     nid: 10.200.245.133@tcp
+    #             status: up
+    #             interfaces:
+    #                   0: enp5s0
+    #
+    # Gives mapping: `{'lo': [], 'o2ib': ['enp6s0', 'enp7s0'], 'tcp': ['enp5s0']}`
+
+    try:
+        data = yaml.safe_load(show_output)
+    except yaml.YAMLError as e:
+        raise LNetError("Failed to parse LNet network output") from e
+
+    if data is None:
+        raise LNetError("Empty LNet network output")
+
+    try:
+        parsed = _NetShowOutput.model_validate(data)
+    except ValidationError as e:
+        raise LNetError(f"Failed to validate LNet network output: {data}") from e
+
+    if not parsed.net:
+        # TODO: Confirm if this should be an error. Empty "net" indicates no networks configured,
+        # not even "lo". Valid or is `lnetctl` output malformed?
+        _logger.warning("No LNet networks found in output: %s", data)
+        return {}
+
+    networks: dict[str, list[str]] = {}
+    for net in parsed.net:
+        interfaces: list[str] = []
+        for ni in net.local_nis:
+            interfaces.extend(ni.interfaces.values())
+        networks[net.net_type] = interfaces
+
+    return networks
+
+
+def _remove_interfaces(net: str, interfaces: set[str]) -> None:
+    """Remove interfaces from an existing LNet network.
+
+    Args:
+        net: The LNet network name (e.g. ``tcp0``).
+        interfaces: The interfaces to remove.
+
+    Raises:
+        LNetError: If removing the interfaces fails.
+    """
+    cmd = [LNETCTL_EXECUTABLE, "interface", "del", "--net", net]
+    for iface in interfaces:
+        cmd += ["--if", iface]
+
+    try:
+        subprocess.run(cmd, check=True)
+    except (subprocess.CalledProcessError, FileNotFoundError) as e:
+        raise LNetError(f"Failed to remove interfaces {interfaces} from LNet network {net}") from e

--- a/internal/lustre-ops/src/lustre_ops/lnet.py
+++ b/internal/lustre-ops/src/lustre_ops/lnet.py
@@ -278,12 +278,12 @@ def _persist_lnet_config() -> None:
         tmp.touch(mode=0o600)
         tmp.write_text(result)
         tmp.replace(LUSTRE_LNET_CONF)
-    except (subprocess.CalledProcessError, FileNotFoundError, OSError) as e:
+    except (subprocess.CalledProcessError, OSError) as e:
         raise LNetConfigExportError("Failed to write LNet configuration data") from e
 
 
 def _parse_networks(show_output: str) -> dict[str, list[str]]:
-    """Parse all networks and their bound interfaces from ``lnetctl net show`` output.
+    r"""Parse all networks and their bound interfaces from ``lnetctl net show`` output.
 
     Args:
         show_output: The raw stdout of ``lnetctl net show``.
@@ -293,33 +293,34 @@ def _parse_networks(show_output: str) -> dict[str, list[str]]:
 
     Raises:
         LNetParseError: If the given string cannot be parsed.
-    """
-    # Sample `lnetctl net show`:
-    #
-    # net:
-    # -     net type: lo
-    #       local NI(s):
-    #       -     nid: 0@lo
-    #             status: up
-    # -     net type: o2ib
-    #       local NI(s):
-    #       -     nid: 10.0.0.10@o2ib
-    #             status: up
-    #             interfaces:
-    #                   0: enp6s0
-    #       -     nid: 10.0.0.11@o2ib
-    #             status: up
-    #             interfaces:
-    #                   0: enp7s0
-    # -     net type: tcp
-    #       local NI(s):
-    #       -     nid: 10.200.245.133@tcp
-    #             status: up
-    #             interfaces:
-    #                   0: enp5s0
-    #
-    # Gives mapping: `{'lo': [], 'o2ib': ['enp6s0', 'enp7s0'], 'tcp': ['enp5s0']}`
 
+    Examples:
+        >>> show_output = '''\
+        ... net:
+        ... -     net type: lo
+        ...       local NI(s):
+        ...       -     nid: 0@lo
+        ...             status: up
+        ... -     net type: o2ib
+        ...       local NI(s):
+        ...       -     nid: 10.0.0.10@o2ib
+        ...             status: up
+        ...             interfaces:
+        ...                   0: enp6s0
+        ...       -     nid: 10.0.0.11@o2ib
+        ...             status: up
+        ...             interfaces:
+        ...                   0: enp7s0
+        ... -     net type: tcp
+        ...       local NI(s):
+        ...       -     nid: 10.200.245.133@tcp
+        ...             status: up
+        ...             interfaces:
+        ...                   0: enp5s0
+        ... '''
+        >>> _parse_networks(show_output)
+        {'lo': [], 'o2ib': ['enp6s0', 'enp7s0'], 'tcp': ['enp5s0']}
+    """
     try:
         data = yaml.safe_load(show_output)
     except yaml.YAMLError as e:

--- a/internal/lustre-ops/src/lustre_ops/lnet_detection.py
+++ b/internal/lustre-ops/src/lustre_ops/lnet_detection.py
@@ -1,0 +1,159 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details
+
+"""Auto-detection of LNet networks from host interfaces."""
+
+import json
+import logging
+import subprocess
+
+from lustre_ops.constants import IP_EXECUTABLE, RDMA_EXECUTABLE, SYS_CLASS_NET
+from lustre_ops.errors import LNetError
+
+_logger = logging.getLogger(__name__)
+
+
+def detect_networks() -> dict[str, list[str]]:
+    """Auto-detect the LNet networks to configure on this unit.
+
+    Returns a dict containing:
+        - One ``tcp`` network specifying the default-route interface (if any).
+        - One ``o2ib`` network specifying every RDMA netdev detected (multi-rail when >1).
+
+    Returns:
+        The detected LNet networks. May be empty if neither a default route nor any RDMA devices are
+        present.
+
+    Raises:
+        LNetError: If detection fails.
+    """
+    networks: dict[str, list[str]] = {}
+
+    default_interface = _default_route_interface()
+    _logger.info("auto-detected TCP interfaces: %s", default_interface)
+    if default_interface is not None:
+        networks["tcp"] = [default_interface]
+
+    rdma_interfaces = _rdma_interfaces()
+    _logger.info("auto-detected RDMA interfaces: %s", rdma_interfaces)
+    if rdma_interfaces:
+        networks["o2ib"] = rdma_interfaces
+
+    return networks
+
+
+def _default_route_interface() -> str | None:
+    """Return the default-route interface name, or ``None`` if there is none.
+
+    Raises:
+        LNetError: If querying or parsing the default route fails.
+    """
+    try:
+        result = subprocess.run(
+            [IP_EXECUTABLE, "-json", "route", "show", "default"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError) as e:
+        raise LNetError("Failed to query default network interface") from e
+
+    try:
+        routes = json.loads(result.stdout)
+    except json.JSONDecodeError as e:
+        raise LNetError("Failed to parse default route data") from e
+
+    if not routes:
+        return None
+    try:
+        return routes[0]["dev"]
+    except KeyError as e:
+        raise LNetError("Failed to extract default network interface from route data") from e
+
+
+def _ipoib_netdev_map() -> dict[str, str]:
+    """Build a mapping of RDMA device name to netdev for native IPoIB devices.
+
+    Returns:
+        A mapping from RDMA device name (example: ``mlx5_0``) to netdev name (example: ``ib0``). May
+        be empty if no IPoIB devices are present.
+    """
+    # IPoIB devices are represented in sysfs at `/sys/class/net/*/device/infiniband`. Scan this for
+    # netdevs backed by an InfiniBand device.
+    rdma_net_map: dict[str, str] = {}
+    for netdev in SYS_CLASS_NET.iterdir():
+        ib_path = netdev / "device/infiniband"
+        if not ib_path.exists():
+            continue
+
+        ib_devs = list(ib_path.iterdir())
+        if len(ib_devs) != 1:
+            _logger.warning(
+                "unexpected number of InfiniBand devices for netdev %s. expected 1, got: %s",
+                netdev.name,
+                ib_devs,
+            )
+            continue
+
+        rdma_net_map[ib_devs[0].name] = netdev.name
+    return rdma_net_map
+
+
+def _rdma_interfaces() -> list[str]:
+    """Return netdev names associated with RDMA devices on this unit.
+
+    Returns:
+        A list of netdev names (e.g. ``ib0``, ``ib1``) for all RDMA devices that are active and have
+        a physical link up. Empty if no RDMA devices are present or none are active.
+
+    Raises:
+        LNetError: If detection fails.
+    """
+    try:
+        result = subprocess.run(
+            [RDMA_EXECUTABLE, "--json", "link", "show"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except FileNotFoundError as e:
+        raise LNetError(f"Failed to query RDMA links: {RDMA_EXECUTABLE} not found") from e
+    except subprocess.CalledProcessError as e:
+        raise LNetError("Failed to query RDMA links") from e
+
+    try:
+        links = json.loads(result.stdout)
+    except json.JSONDecodeError as e:
+        raise LNetError("Failed to parse RDMA link data") from e
+
+    # Map of RDMA device (e.g. mlx5_0) to IPoIB netdev (e.g. ib0) is necessary as the `rdma` command
+    # does not give the netdev for IPoIB devices. LNet requires netdev name for o2ib networks (RDMA
+    # device name is not sufficient).
+    ipoib_map = _ipoib_netdev_map()
+
+    seen_interfaces: set[str] = set()
+    for link in links:
+        if not (link.get("state") == "ACTIVE" and link.get("physical_state") == "LINK_UP"):
+            _logger.info("ignoring inactive RDMA link: %s", link)
+            continue
+
+        netdev = link.get("netdev")
+        if not netdev:
+            _logger.debug("RDMA link has no netdev: %s", link)
+
+            ifname = link.get("ifname")
+            if not ifname:
+                _logger.warning("RDMA link has no ifname: %s", link)
+                continue
+
+            netdev = ipoib_map.get(ifname)
+            if not netdev:
+                _logger.warning("no IPoIB netdev found for RDMA device %s", ifname)
+                continue
+
+        if netdev not in seen_interfaces:
+            seen_interfaces.add(netdev)
+            _logger.debug("detected RDMA interface %s for link %s", netdev, link)
+
+    rdma_interfaces = sorted(seen_interfaces)
+    return rdma_interfaces

--- a/internal/lustre-ops/src/lustre_ops/lnet_detection.py
+++ b/internal/lustre-ops/src/lustre_ops/lnet_detection.py
@@ -8,7 +8,7 @@ import logging
 import subprocess
 
 from lustre_ops.constants import IP_EXECUTABLE, RDMA_EXECUTABLE, SYS_CLASS_NET
-from lustre_ops.errors import LNetError
+from lustre_ops.errors import LNetParseError, LNetQueryError
 
 _logger = logging.getLogger(__name__)
 
@@ -25,7 +25,7 @@ def detect_networks() -> dict[str, list[str]]:
         present.
 
     Raises:
-        LNetError: If detection fails.
+        LNetAutodetectError: If detection fails.
     """
     networks: dict[str, list[str]] = {}
 
@@ -46,7 +46,8 @@ def _default_route_interface() -> str | None:
     """Return the default-route interface name, or ``None`` if there is none.
 
     Raises:
-        LNetError: If querying or parsing the default route fails.
+        LNetQueryError: If querying the default route fails.
+        LNetParseError: If parsing the default route data fails.
     """
     try:
         result = subprocess.run(
@@ -56,19 +57,19 @@ def _default_route_interface() -> str | None:
             check=True,
         )
     except (subprocess.CalledProcessError, FileNotFoundError) as e:
-        raise LNetError("Failed to query default network interface") from e
+        raise LNetQueryError("Failed to query default network interface") from e
 
     try:
         routes = json.loads(result.stdout)
     except json.JSONDecodeError as e:
-        raise LNetError("Failed to parse default route data") from e
+        raise LNetParseError("Failed to parse default route data") from e
 
     if not routes:
         return None
     try:
         return routes[0]["dev"]
     except KeyError as e:
-        raise LNetError("Failed to extract default network interface from route data") from e
+        raise LNetParseError("Failed to extract default network interface from route data") from e
 
 
 def _ipoib_netdev_map() -> dict[str, str]:
@@ -107,7 +108,8 @@ def _rdma_interfaces() -> list[str]:
         a physical link up. Empty if no RDMA devices are present or none are active.
 
     Raises:
-        LNetError: If detection fails.
+        LNetQueryError: If querying RDMA links fails.
+        LNetParseError: If parsing RDMA link data fails.
     """
     try:
         result = subprocess.run(
@@ -117,14 +119,14 @@ def _rdma_interfaces() -> list[str]:
             check=True,
         )
     except FileNotFoundError as e:
-        raise LNetError(f"Failed to query RDMA links: {RDMA_EXECUTABLE} not found") from e
+        raise LNetQueryError(f"Failed to query RDMA links: {RDMA_EXECUTABLE} not found") from e
     except subprocess.CalledProcessError as e:
-        raise LNetError("Failed to query RDMA links") from e
+        raise LNetQueryError("Failed to query RDMA links") from e
 
     try:
         links = json.loads(result.stdout)
     except json.JSONDecodeError as e:
-        raise LNetError("Failed to parse RDMA link data") from e
+        raise LNetParseError("Failed to parse RDMA link data") from e
 
     # Map of RDMA device (e.g. mlx5_0) to IPoIB netdev (e.g. ib0) is necessary as the `rdma` command
     # does not give the netdev for IPoIB devices. LNet requires netdev name for o2ib networks (RDMA

--- a/internal/lustre-ops/src/lustre_ops/ppa.py
+++ b/internal/lustre-ops/src/lustre_ops/ppa.py
@@ -1,0 +1,47 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details
+
+"""Lustre package repository setup."""
+
+import platform
+from subprocess import CalledProcessError
+
+from charmlibs import apt
+
+from lustre_ops.constants import LUSTRE_REPOSITORY_KEY, LUSTRE_REPOSITORY_URI
+from lustre_ops.errors import RepositoryError
+
+_LUSTRE_REPO_FILENAME = "lustre-repo"
+_LUSTRE_REPO_GROUPS = ["main"]
+
+
+def setup_lustre_repository() -> None:
+    """Configure the Lustre package repository. Idempotent.
+
+    Raises:
+        RepositoryError: If repository setup fails.
+    """
+    try:
+        release = platform.freedesktop_os_release()["VERSION_CODENAME"]
+    except KeyError as e:
+        raise RepositoryError("Failed to determine OS version codename") from e
+
+    repo = apt.DebianRepository(
+        enabled=True,
+        repotype="deb",
+        uri=LUSTRE_REPOSITORY_URI,
+        release=release,
+        groups=_LUSTRE_REPO_GROUPS,
+        filename=_LUSTRE_REPO_FILENAME,
+    )
+
+    try:
+        repo.import_key(LUSTRE_REPOSITORY_KEY)
+    except apt.GPGKeyError as e:
+        raise RepositoryError("Failed to import Lustre repository GPG key") from e
+
+    try:
+        apt.RepositoryMapping().add(repo)
+        apt.update()
+    except CalledProcessError as e:
+        raise RepositoryError("Failed to add or refresh Lustre repository") from e

--- a/internal/lustre-ops/src/lustre_ops/ppa.py
+++ b/internal/lustre-ops/src/lustre_ops/ppa.py
@@ -9,7 +9,7 @@ from subprocess import CalledProcessError
 from charmlibs import apt
 
 from lustre_ops.constants import LUSTRE_REPOSITORY_KEY, LUSTRE_REPOSITORY_URI
-from lustre_ops.errors import RepositoryError
+from lustre_ops.errors import RepositoryCodenameError, RepositoryGPGKeyError, RepositorySyncError
 
 _LUSTRE_REPO_FILENAME = "lustre-repo"
 _LUSTRE_REPO_GROUPS = ["main"]
@@ -19,12 +19,14 @@ def setup_lustre_repository() -> None:
     """Configure the Lustre package repository. Idempotent.
 
     Raises:
-        RepositoryError: If repository setup fails.
+        RepositoryCodenameError: If the OS version codename cannot be determined.
+        RepositoryGPGKeyError: If the Lustre repository GPG key cannot be imported.
+        RepositorySyncError: If the repository cannot be added or refreshed.
     """
     try:
         release = platform.freedesktop_os_release()["VERSION_CODENAME"]
     except KeyError as e:
-        raise RepositoryError("Failed to determine OS version codename") from e
+        raise RepositoryCodenameError("Failed to determine OS version codename") from e
 
     repo = apt.DebianRepository(
         enabled=True,
@@ -38,10 +40,10 @@ def setup_lustre_repository() -> None:
     try:
         repo.import_key(LUSTRE_REPOSITORY_KEY)
     except apt.GPGKeyError as e:
-        raise RepositoryError("Failed to import Lustre repository GPG key") from e
+        raise RepositoryGPGKeyError("Failed to import Lustre repository GPG key") from e
 
     try:
         apt.RepositoryMapping().add(repo)
         apt.update()
     except CalledProcessError as e:
-        raise RepositoryError("Failed to add or refresh Lustre repository") from e
+        raise RepositorySyncError("Failed to add or refresh Lustre repository") from e

--- a/internal/lustre-ops/tests/unit/test_lnet.py
+++ b/internal/lustre-ops/tests/unit/test_lnet.py
@@ -12,7 +12,15 @@ import pytest
 import yaml
 from lustre_ops import lnet
 from lustre_ops.constants import LCTL_EXECUTABLE, LNETCTL_EXECUTABLE
-from lustre_ops.errors import LNetError
+from lustre_ops.errors import (
+    LNetAddInterfaceError,
+    LNetAddNetworkError,
+    LNetAutodetectError,
+    LNetConfigExportError,
+    LNetParseError,
+    LNetQueryError,
+    LNetRemoveInterfaceError,
+)
 from pytest_mock import MockerFixture
 
 
@@ -99,10 +107,10 @@ class TestInit:
         mock_persist: MagicMock,
         mock_detect: MagicMock,
     ) -> None:
-        """init(networks=None) raises LNetError when auto-detection finds no networks."""
+        """init(networks=None) raises error when auto-detection finds no networks."""
         mock_detect.return_value = {}
 
-        with pytest.raises(LNetError):
+        with pytest.raises(LNetAutodetectError):
             lnet.init(networks=None)
 
 
@@ -196,7 +204,7 @@ class TestEnsureNetworks:
         ]
 
     def test_add_interface_failure_raises(self, mock_run: MagicMock) -> None:
-        """A failure on interface add raises LNetError."""
+        """A failure on interface add raises error."""
         mock_run.return_value.stdout = _net_show_output({"o2ib": ["ib0"]})
         mock_run.side_effect = [
             mock_run.return_value,
@@ -204,11 +212,11 @@ class TestEnsureNetworks:
         ]
         nets = {"o2ib": ["ib0", "ib1"]}
 
-        with pytest.raises(LNetError):
+        with pytest.raises(LNetAddInterfaceError):
             lnet._ensure_networks(nets)
 
     def test_remove_interface_failure_raises(self, mock_run: MagicMock) -> None:
-        """A failure on interface removal raises LNetError."""
+        """A failure on interface removal raises error."""
         mock_run.return_value.stdout = _net_show_output({"tcp": ["eth0", "eth1"]})
         mock_run.side_effect = [
             mock_run.return_value,
@@ -216,18 +224,18 @@ class TestEnsureNetworks:
         ]
         nets = {"tcp": ["eth0"]}  # eth1 is stale and should be removed
 
-        with pytest.raises(LNetError):
+        with pytest.raises(LNetRemoveInterfaceError):
             lnet._ensure_networks(nets)
 
     def test_net_add_failure_raises(self, mock_run: MagicMock) -> None:
-        """A failure adding a missing network raises LNetError."""
+        """A failure adding a missing network raises error."""
         mock_run.side_effect = [
             mock_run.return_value,
             subprocess.CalledProcessError(1, LNETCTL_EXECUTABLE),
         ]
         nets = {"tcp": ["eth0"]}
 
-        with pytest.raises(LNetError):
+        with pytest.raises(LNetAddNetworkError):
             lnet._ensure_networks(nets)
 
     def test_multiple_networks(self, mock_run: MagicMock) -> None:
@@ -282,24 +290,22 @@ class TestEnsureNetworks:
         ]
 
     def test_lnetctl_not_found_on_show(self, mock_run: MagicMock) -> None:
-        """FileNotFoundError on net show raises LNetError."""
+        """FileNotFoundError on net show raises error."""
         mock_run.side_effect = FileNotFoundError(1, "/bad/path/to/lnetctl")
         nets = {"tcp": ["eth0"]}
 
-        with pytest.raises(LNetError) as excinfo:
+        with pytest.raises(LNetQueryError):
             lnet._ensure_networks(nets)
-        assert isinstance(excinfo.value.__cause__, FileNotFoundError)
 
     def test_net_show_failure_raises(self, mock_run: MagicMock) -> None:
-        """A non-zero exit from net show raises LNetError."""
+        """A non-zero exit from net show raises error."""
         mock_run.side_effect = subprocess.CalledProcessError(
             1, LNETCTL_EXECUTABLE, stderr="error running lnetctl net show"
         )
         nets = {"tcp": ["eth0"]}
 
-        with pytest.raises(LNetError) as excinfo:
+        with pytest.raises(LNetQueryError):
             lnet._ensure_networks(nets)
-        assert isinstance(excinfo.value.__cause__, subprocess.CalledProcessError)
 
 
 class TestParseNetworkConfig:
@@ -348,8 +354,8 @@ class TestParseNetworkConfig:
         ],
     )
     def test_invalid_raises(self, spec: str, match: str) -> None:
-        """A malformed specification raises LNetError with a descriptive message."""
-        with pytest.raises(LNetError, match=match):
+        """A malformed specification raises error with a descriptive message."""
+        with pytest.raises(LNetParseError, match=match):
             lnet.parse_network_config(spec)
 
     def test_trailing_zero_equivalent_to_bare_name(self) -> None:
@@ -378,9 +384,9 @@ class TestParseNetworks:
         assert lnet._parse_networks(output) == {"tcp": []}
 
     def test_no_local_nis_raises(self) -> None:
-        """A network with no 'local NI(s)' raises LNetError."""
+        """A network with no 'local NI(s)' raises error."""
         output = "net:\n-    net type: tcp\n"
-        with pytest.raises(LNetError, match="Failed to validate LNet network output"):
+        with pytest.raises(LNetParseError, match="Failed to validate LNet network output"):
             lnet._parse_networks(output)
 
     def test_multi_ni_multi_rail(self) -> None:
@@ -396,8 +402,8 @@ class TestParseNetworks:
         ) == {"o2ib": ["enp6s0"], "o2ib1": ["enp5s0"]}
 
     def test_empty_output_raises(self) -> None:
-        """Empty stdout raises LNetError."""
-        with pytest.raises(LNetError, match="Empty LNet network output"):
+        """Empty stdout raises error."""
+        with pytest.raises(LNetParseError, match="Empty LNet network output"):
             lnet._parse_networks("")
 
     def test_no_nets_returns_empty(self) -> None:
@@ -405,8 +411,8 @@ class TestParseNetworks:
         assert lnet._parse_networks("net:\n") == {}
 
     def test_malformed_yaml_raises(self) -> None:
-        """Malformed YAML raises LNetError."""
-        with pytest.raises(LNetError, match="Failed to parse LNet network output"):
+        """Malformed YAML raises error."""
+        with pytest.raises(LNetParseError, match="Failed to parse LNet network output"):
             lnet._parse_networks("net:\n    - [unclosed")
 
 
@@ -435,29 +441,24 @@ class TestGetNids:
         )
 
     @pytest.mark.parametrize(
-        ("side_effect", "expected_cause"),
+        ("side_effect"),
         [
             pytest.param(
                 subprocess.CalledProcessError(1, LCTL_EXECUTABLE),
-                subprocess.CalledProcessError,
                 id="run_error",
             ),
             pytest.param(
                 FileNotFoundError(1, "/bad/path/to/lctl"),
-                FileNotFoundError,
                 id="not_found",
             ),
         ],
     )
-    def test_error_wrapped_as_lnet_error(
-        self, mock_run: MagicMock, side_effect: Exception, expected_cause: type
-    ) -> None:
-        """Errors from lctl are wrapped in LNetError with the original cause chained."""
+    def test_nid_errors(self, mock_run: MagicMock, side_effect: Exception) -> None:
+        """Errors from lctl are raised."""
         mock_run.side_effect = side_effect
 
-        with pytest.raises(LNetError) as excinfo:
+        with pytest.raises(LNetQueryError):
             lnet.get_nids()
-        assert isinstance(excinfo.value.__cause__, expected_cause)
 
 
 class TestPersistLnetConfig:
@@ -480,6 +481,5 @@ class TestPersistLnetConfig:
         """Lnetctl export failure."""
         mock_run.side_effect = subprocess.CalledProcessError(1, LNETCTL_EXECUTABLE)
 
-        with pytest.raises(LNetError) as excinfo:
+        with pytest.raises(LNetConfigExportError):
             lnet._persist_lnet_config()
-        assert isinstance(excinfo.value.__cause__, subprocess.CalledProcessError)

--- a/internal/lustre-ops/tests/unit/test_lnet.py
+++ b/internal/lustre-ops/tests/unit/test_lnet.py
@@ -1,0 +1,485 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details
+
+"""Unit tests for `lustre_ops.lnet`."""
+
+import stat
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+import yaml
+from lustre_ops import lnet
+from lustre_ops.constants import LCTL_EXECUTABLE, LNETCTL_EXECUTABLE
+from lustre_ops.errors import LNetError
+from pytest_mock import MockerFixture
+
+
+@pytest.fixture(scope="function")
+def mock_run(mocker: MockerFixture) -> MagicMock:
+    """Mock subprocess.run."""
+    return mocker.patch("lustre_ops.lnet.subprocess.run")
+
+
+def _net_show_output(networks: dict[str, list[str]] | None = None) -> str:
+    """Build realistic ``lnetctl net show`` YAML output.
+
+    Args:
+        networks: Mapping of net type to interfaces.
+    """
+    networks = networks or {}
+    nets = []
+    for net_type, ifaces in networks.items():
+        nets.append(
+            {
+                "net type": net_type,
+                "local NI(s)": [
+                    {
+                        "nid": f"10.0.0.1@{net_type}",
+                        "status": "up",
+                        "interfaces": {"0": iface},
+                    }
+                    for iface in ifaces
+                ],
+            }
+        )
+    return yaml.safe_dump({"net": nets}, sort_keys=False)
+
+
+class TestInit:
+    """init() tests."""
+
+    @pytest.fixture(scope="function")
+    def mock_ensure(self, mocker: MockerFixture) -> MagicMock:
+        """Mock lustre_ops.lnet._ensure_networks."""
+        return mocker.patch("lustre_ops.lnet._ensure_networks", autospec=True)
+
+    @pytest.fixture(scope="function")
+    def mock_persist(self, mocker: MockerFixture) -> MagicMock:
+        """Mock lustre_ops.lnet._persist_lnet_config."""
+        return mocker.patch("lustre_ops.lnet._persist_lnet_config", autospec=True)
+
+    @pytest.fixture(scope="function")
+    def mock_detect(self, mocker: MockerFixture) -> MagicMock:
+        """Mock lustre_ops.lnet_detection.detect_networks."""
+        return mocker.patch("lustre_ops.lnet.detect_networks", autospec=True)
+
+    def test_explicit_networks(
+        self,
+        mock_ensure: MagicMock,
+        mock_persist: MagicMock,
+        mock_detect: MagicMock,
+    ) -> None:
+        """init() with explicit networks persists config without auto-detection."""
+        nets = {"tcp": ["eth0"], "o2ib": ["ib0", "ib1"]}
+        lnet.init(networks=nets)
+
+        mock_ensure.assert_called_once_with(nets)
+        mock_persist.assert_called_once()
+        mock_detect.assert_not_called()
+
+    def test_auto_detected_networks(
+        self,
+        mock_ensure: MagicMock,
+        mock_persist: MagicMock,
+        mock_detect: MagicMock,
+    ) -> None:
+        """init(networks=None) autodetects networks."""
+        detected = {"tcp": ["eth0"], "o2ib": ["ib0", "ib1"]}
+        mock_detect.return_value = detected
+
+        lnet.init(networks=None)
+
+        mock_ensure.assert_called_once_with(detected)
+
+    def test_auto_detection_no_networks(
+        self,
+        mock_ensure: MagicMock,
+        mock_persist: MagicMock,
+        mock_detect: MagicMock,
+    ) -> None:
+        """init(networks=None) raises LNetError when auto-detection finds no networks."""
+        mock_detect.return_value = {}
+
+        with pytest.raises(LNetError):
+            lnet.init(networks=None)
+
+
+class TestEnsureNetworks:
+    """_ensure_networks() tests."""
+
+    @pytest.fixture(autouse=True)
+    def _default_show(self, mock_run: MagicMock) -> None:
+        """Default `lnetctl net show` that returns no configured networks."""
+        mock_run.return_value = MagicMock(returncode=0, stdout=_net_show_output())
+
+    def test_adds_missing_network_single_interface(self, mock_run: MagicMock) -> None:
+        """A missing network is added with a single interface."""
+        nets = {"tcp": ["eth0"]}
+
+        lnet._ensure_networks(nets)
+
+        # Two calls: `lnetctl net show` then `lnetctl net add`.
+        assert mock_run.call_count == 2
+        add_call = mock_run.call_args_list[1]
+        assert add_call[0][0] == [LNETCTL_EXECUTABLE, "net", "add", "--net", "tcp", "--if", "eth0"]
+
+    def test_adds_missing_network_multi_rail(self, mock_run: MagicMock) -> None:
+        """A missing network is added with multi-rail interfaces."""
+        nets = {"o2ib": ["ib0", "ib1"]}
+
+        lnet._ensure_networks(nets)
+
+        # Two calls: `lnetctl net show` then `lnetctl net add`.
+        assert mock_run.call_count == 2
+        add_call = mock_run.call_args_list[1]
+        assert add_call[0][0] == [
+            LNETCTL_EXECUTABLE,
+            "net",
+            "add",
+            "--net",
+            "o2ib",
+            "--if",
+            "ib0",
+            "--if",
+            "ib1",
+        ]
+
+    def test_skips_when_network_and_interfaces_exist(self, mock_run: MagicMock) -> None:
+        """An existing network with matching interfaces is left untouched."""
+        nets = {"tcp": ["eth0"]}
+        mock_run.return_value.stdout = _net_show_output(nets)
+
+        lnet._ensure_networks(nets)
+
+        # No add/del calls
+        assert mock_run.call_count == 1
+        assert mock_run.call_args_list[0][0][0] == [LNETCTL_EXECUTABLE, "net", "show"]
+
+    def test_adds_missing_interface_to_existing_network(self, mock_run: MagicMock) -> None:
+        """A missing interface is added to an existing network (multi-rail expansion)."""
+        mock_run.return_value.stdout = _net_show_output({"o2ib": ["ib0"]})
+        nets = {"o2ib": ["ib0", "ib1"]}
+
+        lnet._ensure_networks(nets)
+
+        # net show, then interface add for ib1.
+        assert mock_run.call_count == 2
+        add_call = mock_run.call_args_list[1]
+        assert add_call[0][0] == [
+            LNETCTL_EXECUTABLE,
+            "interface",
+            "add",
+            "--net",
+            "o2ib",
+            "--if",
+            "ib1",
+        ]
+
+    def test_removes_stale_interface_from_existing_network(self, mock_run: MagicMock) -> None:
+        """A bound interface not in the desired set is removed."""
+        mock_run.return_value.stdout = _net_show_output({"tcp": ["eth0", "eth1"]})
+        nets = {"tcp": ["eth0"]}
+
+        lnet._ensure_networks(nets)
+
+        del_call = mock_run.call_args_list[1]
+        assert del_call[0][0] == [
+            LNETCTL_EXECUTABLE,
+            "interface",
+            "del",
+            "--net",
+            "tcp",
+            "--if",
+            "eth1",
+        ]
+
+    def test_add_interface_failure_raises(self, mock_run: MagicMock) -> None:
+        """A failure on interface add raises LNetError."""
+        mock_run.return_value.stdout = _net_show_output({"o2ib": ["ib0"]})
+        mock_run.side_effect = [
+            mock_run.return_value,
+            subprocess.CalledProcessError(1, LNETCTL_EXECUTABLE),
+        ]
+        nets = {"o2ib": ["ib0", "ib1"]}
+
+        with pytest.raises(LNetError):
+            lnet._ensure_networks(nets)
+
+    def test_remove_interface_failure_raises(self, mock_run: MagicMock) -> None:
+        """A failure on interface removal raises LNetError."""
+        mock_run.return_value.stdout = _net_show_output({"tcp": ["eth0", "eth1"]})
+        mock_run.side_effect = [
+            mock_run.return_value,
+            subprocess.CalledProcessError(1, LNETCTL_EXECUTABLE),
+        ]
+        nets = {"tcp": ["eth0"]}  # eth1 is stale and should be removed
+
+        with pytest.raises(LNetError):
+            lnet._ensure_networks(nets)
+
+    def test_net_add_failure_raises(self, mock_run: MagicMock) -> None:
+        """A failure adding a missing network raises LNetError."""
+        mock_run.side_effect = [
+            mock_run.return_value,
+            subprocess.CalledProcessError(1, LNETCTL_EXECUTABLE),
+        ]
+        nets = {"tcp": ["eth0"]}
+
+        with pytest.raises(LNetError):
+            lnet._ensure_networks(nets)
+
+    def test_multiple_networks(self, mock_run: MagicMock) -> None:
+        """Multiple new networks are successfully added."""
+        nets = {
+            "tcp": ["eth0"],
+            "o2ib": ["ib0", "ib1"],
+        }
+
+        lnet._ensure_networks(nets)
+
+        # One net show call then two net add calls.
+        assert mock_run.call_count == 3
+        assert mock_run.call_args_list[1][0][0] == [
+            LNETCTL_EXECUTABLE,
+            "net",
+            "add",
+            "--net",
+            "tcp",
+            "--if",
+            "eth0",
+        ]
+        assert mock_run.call_args_list[2][0][0] == [
+            LNETCTL_EXECUTABLE,
+            "net",
+            "add",
+            "--net",
+            "o2ib",
+            "--if",
+            "ib0",
+            "--if",
+            "ib1",
+        ]
+
+    def test_nonzero_net_seq(self, mock_run: MagicMock) -> None:
+        """A new network with a non-zero net_seq is added."""
+        nets = {"o2ib1": ["ib2"]}
+
+        lnet._ensure_networks(nets)
+
+        show_call = mock_run.call_args_list[0]
+        assert show_call[0][0] == [LNETCTL_EXECUTABLE, "net", "show"]
+        add_call = mock_run.call_args_list[1]
+        assert add_call[0][0] == [
+            LNETCTL_EXECUTABLE,
+            "net",
+            "add",
+            "--net",
+            "o2ib1",
+            "--if",
+            "ib2",
+        ]
+
+    def test_lnetctl_not_found_on_show(self, mock_run: MagicMock) -> None:
+        """FileNotFoundError on net show raises LNetError."""
+        mock_run.side_effect = FileNotFoundError(1, "/bad/path/to/lnetctl")
+        nets = {"tcp": ["eth0"]}
+
+        with pytest.raises(LNetError) as excinfo:
+            lnet._ensure_networks(nets)
+        assert isinstance(excinfo.value.__cause__, FileNotFoundError)
+
+    def test_net_show_failure_raises(self, mock_run: MagicMock) -> None:
+        """A non-zero exit from net show raises LNetError."""
+        mock_run.side_effect = subprocess.CalledProcessError(
+            1, LNETCTL_EXECUTABLE, stderr="error running lnetctl net show"
+        )
+        nets = {"tcp": ["eth0"]}
+
+        with pytest.raises(LNetError) as excinfo:
+            lnet._ensure_networks(nets)
+        assert isinstance(excinfo.value.__cause__, subprocess.CalledProcessError)
+
+
+class TestParseNetworkConfig:
+    """parse_network_config() tests."""
+
+    @pytest.mark.parametrize(
+        ("spec", "expected"),
+        [
+            pytest.param("tcp0=eth0", {"tcp": ["eth0"]}, id="single_network_single_interface"),
+            pytest.param(
+                "o2ib0=ib0,ib1", {"o2ib": ["ib0", "ib1"]}, id="single_network_multi_rail"
+            ),
+            pytest.param(
+                "tcp0=eth0; o2ib0=ib0,ib1",
+                {"tcp": ["eth0"], "o2ib": ["ib0", "ib1"]},
+                id="multiple_networks",
+            ),
+            pytest.param("o2ib1=ib2", {"o2ib1": ["ib2"]}, id="nonzero_seq"),
+            pytest.param(
+                "  tcp0 = eth0 , eth1  ", {"tcp": ["eth0", "eth1"]}, id="strips_whitespace"
+            ),
+            pytest.param("tcp=eth0;;", {"tcp": ["eth0"]}, id="empty_token_skipped"),
+            pytest.param("o2ib10=ib0", {"o2ib10": ["ib0"]}, id="multi_digit_name_not_stripped"),
+            pytest.param("o2ib0=ib0", {"o2ib": ["ib0"]}, id="zero_seq_stripped"),
+        ],
+    )
+    def test_parse_valid(self, spec: str, expected: dict[str, list[str]]) -> None:
+        """Valid specifications parse to the expected network mapping."""
+        assert lnet.parse_network_config(spec) == expected
+
+    @pytest.mark.parametrize(
+        "spec",
+        [pytest.param("", id="empty_string"), pytest.param("   ", id="whitespace_only")],
+    )
+    def test_empty_yields_none(self, spec: str) -> None:
+        """An empty or whitespace-only spec yields ``None``."""
+        assert lnet.parse_network_config(spec) is None
+
+    @pytest.mark.parametrize(
+        ("spec", "match"),
+        [
+            pytest.param("tcp=", "No interfaces", id="no_interfaces"),
+            pytest.param("tcp:eth0", "Invalid LNet network specification", id="no_equals_sign"),
+            pytest.param("=eth0", "Empty network name", id="empty_name"),
+            pytest.param("tcp=eth0;tcp=eth1", "Duplicate LNet network", id="duplicate_network"),
+        ],
+    )
+    def test_invalid_raises(self, spec: str, match: str) -> None:
+        """A malformed specification raises LNetError with a descriptive message."""
+        with pytest.raises(LNetError, match=match):
+            lnet.parse_network_config(spec)
+
+    def test_trailing_zero_equivalent_to_bare_name(self) -> None:
+        """A trailing 0 on a single-digit network name is stripped (tcp0 == tcp)."""
+        assert lnet.parse_network_config("tcp0=eth0") == lnet.parse_network_config("tcp=eth0")
+
+
+class TestParseNetworks:
+    """_parse_networks() tests."""
+
+    def test_extracts_interfaces(self) -> None:
+        """Interfaces are parsed into a list keyed by network name."""
+        assert lnet._parse_networks(_net_show_output({"tcp": ["eth0", "eth1"]})) == {
+            "tcp": ["eth0", "eth1"]
+        }
+
+    def test_no_interfaces(self) -> None:
+        """A NI without an 'interfaces' key contributes no interfaces."""
+        output = (
+            "net:\n"
+            "-    net type: tcp\n"
+            "     local NI(s):\n"
+            "     -    nid: 10.0.0.5@tcp\n"
+            "          status: up\n"
+        )
+        assert lnet._parse_networks(output) == {"tcp": []}
+
+    def test_no_local_nis_raises(self) -> None:
+        """A network with no 'local NI(s)' raises LNetError."""
+        output = "net:\n-    net type: tcp\n"
+        with pytest.raises(LNetError, match="Failed to validate LNet network output"):
+            lnet._parse_networks(output)
+
+    def test_multi_ni_multi_rail(self) -> None:
+        """Interfaces across multiple NIs are all collected."""
+        assert lnet._parse_networks(_net_show_output({"o2ib": ["enp6s0", "enp7s0"]})) == {
+            "o2ib": ["enp6s0", "enp7s0"]
+        }
+
+    def test_distinct_network_names_preserved(self) -> None:
+        """Networks with numeric suffixes are kept distinct."""
+        assert lnet._parse_networks(
+            _net_show_output({"o2ib": ["enp6s0"], "o2ib1": ["enp5s0"]})
+        ) == {"o2ib": ["enp6s0"], "o2ib1": ["enp5s0"]}
+
+    def test_empty_output_raises(self) -> None:
+        """Empty stdout raises LNetError."""
+        with pytest.raises(LNetError, match="Empty LNet network output"):
+            lnet._parse_networks("")
+
+    def test_no_nets_returns_empty(self) -> None:
+        """Output with no 'net' key yields an empty dict."""
+        assert lnet._parse_networks("net:\n") == {}
+
+    def test_malformed_yaml_raises(self) -> None:
+        """Malformed YAML raises LNetError."""
+        with pytest.raises(LNetError, match="Failed to parse LNet network output"):
+            lnet._parse_networks("net:\n    - [unclosed")
+
+
+class TestGetNids:
+    """get_nids() tests."""
+
+    @pytest.mark.parametrize(
+        ("stdout", "expected"),
+        [
+            pytest.param(
+                "10.0.0.5@tcp\n10.0.0.6@tcp\n",
+                ["10.0.0.5@tcp", "10.0.0.6@tcp"],
+                id="multiple_nids",
+            ),
+            pytest.param("", [], id="empty"),
+            pytest.param("\n", [], id="blank_line_only"),
+        ],
+    )
+    def test_returns_nids(self, mock_run: MagicMock, stdout: str, expected: list[str]) -> None:
+        """get_nids() parses lctl stdout into a list of NIDs."""
+        mock_run.return_value.stdout = stdout
+
+        assert lnet.get_nids() == expected
+        mock_run.assert_called_once_with(
+            [LCTL_EXECUTABLE, "list_nids"], capture_output=True, text=True, check=True
+        )
+
+    @pytest.mark.parametrize(
+        ("side_effect", "expected_cause"),
+        [
+            pytest.param(
+                subprocess.CalledProcessError(1, LCTL_EXECUTABLE),
+                subprocess.CalledProcessError,
+                id="run_error",
+            ),
+            pytest.param(
+                FileNotFoundError(1, "/bad/path/to/lctl"),
+                FileNotFoundError,
+                id="not_found",
+            ),
+        ],
+    )
+    def test_error_wrapped_as_lnet_error(
+        self, mock_run: MagicMock, side_effect: Exception, expected_cause: type
+    ) -> None:
+        """Errors from lctl are wrapped in LNetError with the original cause chained."""
+        mock_run.side_effect = side_effect
+
+        with pytest.raises(LNetError) as excinfo:
+            lnet.get_nids()
+        assert isinstance(excinfo.value.__cause__, expected_cause)
+
+
+class TestPersistLnetConfig:
+    """persist_lnet_config() tests."""
+
+    def test_successful_export(
+        self, mocker: MockerFixture, mock_run: MagicMock, tmp_path: Path
+    ) -> None:
+        """Exports the LNet configuration to a file with 0600 permissions."""
+        conf_path = tmp_path / "lnet.conf"
+        mock_run.return_value = MagicMock(returncode=0, stdout="test config data")
+        mocker.patch("lustre_ops.lnet.LUSTRE_LNET_CONF", conf_path)
+
+        lnet._persist_lnet_config()
+
+        assert conf_path.read_text() == "test config data"
+        assert stat.S_IMODE(conf_path.stat().st_mode) == 0o600
+
+    def test_export_failure(self, mock_run: MagicMock) -> None:
+        """Lnetctl export failure."""
+        mock_run.side_effect = subprocess.CalledProcessError(1, LNETCTL_EXECUTABLE)
+
+        with pytest.raises(LNetError) as excinfo:
+            lnet._persist_lnet_config()
+        assert isinstance(excinfo.value.__cause__, subprocess.CalledProcessError)

--- a/internal/lustre-ops/tests/unit/test_lnet_detection.py
+++ b/internal/lustre-ops/tests/unit/test_lnet_detection.py
@@ -1,0 +1,258 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details
+
+"""Unit tests for `lustre_ops.lnet_detection`."""
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from lustre_ops import lnet_detection
+from lustre_ops.errors import LNetError
+from pytest_mock import MockerFixture
+
+
+@pytest.fixture(scope="function")
+def mock_run(mocker: MockerFixture) -> MagicMock:
+    """Mock subprocess.run."""
+    return mocker.patch("lustre_ops.lnet_detection.subprocess.run")
+
+
+class TestDetectNetworks:
+    """detect_networks() tests."""
+
+    @pytest.mark.parametrize(
+        ("default_route", "rdma_ifaces", "expected"),
+        [
+            ("eth0", [], {"tcp": ["eth0"]}),
+            (None, ["ib0", "ib1"], {"o2ib": ["ib0", "ib1"]}),
+            ("eth0", ["ib0", "ib1"], {"tcp": ["eth0"], "o2ib": ["ib0", "ib1"]}),
+            (None, [], {}),
+        ],
+        ids=["ethernet_only", "ib_only", "mixed", "no_interfaces"],
+    )
+    def test_detect_networks(
+        self,
+        mocker: MockerFixture,
+        default_route: str | None,
+        rdma_ifaces: list[str],
+        expected: dict[str, list[str]],
+    ) -> None:
+        """detect_networks() combines the default route and RDMA interfaces."""
+        mocker.patch(
+            "lustre_ops.lnet_detection._default_route_interface", return_value=default_route
+        )
+        mocker.patch("lustre_ops.lnet_detection._rdma_interfaces", return_value=rdma_ifaces)
+
+        assert lnet_detection.detect_networks() == expected
+
+
+class TestDefaultRouteInterface:
+    """_default_route_interface() tests."""
+
+    def test_success(self, mock_run: MagicMock) -> None:
+        """Successfully retrieves the default network interface."""
+        mock_run.return_value.stdout = json.dumps([{"dev": "eth0"}])
+
+        assert lnet_detection._default_route_interface() == "eth0"
+
+    def test_no_default_route(self, mock_run: MagicMock) -> None:
+        """Returns None when there is no default route."""
+        mock_run.return_value.stdout = json.dumps([])
+
+        assert lnet_detection._default_route_interface() is None
+
+    def test_ip_run_error(self, mock_run: MagicMock) -> None:
+        """Ip command fails."""
+        mock_run.side_effect = subprocess.CalledProcessError(1, "ip")
+
+        with pytest.raises(LNetError) as excinfo:
+            lnet_detection._default_route_interface()
+        assert isinstance(excinfo.value.__cause__, subprocess.CalledProcessError)
+
+    def test_bad_json(self, mock_run: MagicMock) -> None:
+        """Ip command returns invalid JSON."""
+        mock_run.return_value.stdout = "not json"
+
+        with pytest.raises(LNetError) as excinfo:
+            lnet_detection._default_route_interface()
+        assert isinstance(excinfo.value.__cause__, json.JSONDecodeError)
+
+    def test_missing_dev_key(self, mock_run: MagicMock) -> None:
+        """Ip command returns JSON without 'dev' key."""
+        mock_run.return_value.stdout = json.dumps([{"not_dev": "eth0"}])
+
+        with pytest.raises(LNetError) as excinfo:
+            lnet_detection._default_route_interface()
+        assert isinstance(excinfo.value.__cause__, KeyError)
+
+
+class TestRdmaInterfaces:
+    """_rdma_interfaces() tests."""
+
+    def _rdma_link(
+        self,
+        ifname: str | None = "mlx5_0",
+        netdev: str | None = "ib0",
+        state: str = "ACTIVE",
+        physical_state: str = "LINK_UP",
+    ) -> dict[str, str | int]:
+        """Build an ``rdma --json link show`` entry with typical default values."""
+        link: dict[str, str | int] = {"port": 1, "state": state, "physical_state": physical_state}
+        if ifname is not None:
+            link["ifname"] = ifname
+        if netdev is not None:
+            link["netdev"] = netdev
+        return link
+
+    def test_finds_netdevs(self, mock_run: MagicMock) -> None:
+        """Parses netdev names from JSON input."""
+        mock_run.return_value.stdout = json.dumps(
+            [
+                self._rdma_link("mlx5_0", netdev="ib0"),
+                self._rdma_link("mlx5_1", netdev="ib1"),
+            ]
+        )
+
+        assert lnet_detection._rdma_interfaces() == ["ib0", "ib1"]
+
+    def test_ethernet_backed_rdma_device(self, mock_run: MagicMock) -> None:
+        """Ethernet-backed RDMA devices (Soft-RoCE rxe devices) are detected."""
+        mock_run.return_value.stdout = json.dumps([self._rdma_link("rxe0", netdev="eth0")])
+
+        assert lnet_detection._rdma_interfaces() == ["eth0"]
+
+    def test_deduplicates_across_links(self, mock_run: MagicMock) -> None:
+        """The same netdev across multiple links is listed only once."""
+        mock_run.return_value.stdout = json.dumps(
+            [
+                self._rdma_link("mlx5_0", netdev="ib0"),
+                self._rdma_link("mlx5_1", netdev="ib0"),
+            ]
+        )
+
+        assert lnet_detection._rdma_interfaces() == ["ib0"]
+
+    def test_no_rdma_devices(self, mock_run: MagicMock) -> None:
+        """An empty rdma link list yields an empty list."""
+        mock_run.return_value.stdout = json.dumps([])
+
+        assert lnet_detection._rdma_interfaces() == []
+
+    def test_skips_inactive_links(self, mock_run: MagicMock) -> None:
+        """Links not in ACTIVE/LINK_UP state are skipped."""
+        mock_run.return_value.stdout = json.dumps(
+            [
+                self._rdma_link("mlx5_0", netdev="ib0", state="DOWN"),
+                self._rdma_link("mlx5_1", netdev="ib1"),
+            ]
+        )
+
+        assert lnet_detection._rdma_interfaces() == ["ib1"]
+
+    def test_sorts_results(self, mock_run: MagicMock) -> None:
+        """Returned netdevs are sorted by name."""
+        mock_run.return_value.stdout = json.dumps(
+            [
+                self._rdma_link("mlx5_1", netdev="ib1"),
+                self._rdma_link("mlx5_0", netdev="ib0"),
+            ]
+        )
+
+        assert lnet_detection._rdma_interfaces() == ["ib0", "ib1"]
+
+    def test_ipoib_lookup_for_missing_netdev(
+        self, mock_run: MagicMock, mocker: MockerFixture
+    ) -> None:
+        """Links without a netdev are resolved via the IPoIB sysfs map."""
+        mock_run.return_value.stdout = json.dumps([self._rdma_link("mlx5_0", netdev=None)])
+        mock_ipoib = mocker.patch(
+            "lustre_ops.lnet_detection._ipoib_netdev_map", return_value={"mlx5_0": "ib0"}
+        )
+
+        assert lnet_detection._rdma_interfaces() == ["ib0"]
+        mock_ipoib.assert_called_once()
+
+    def test_skips_link_with_no_ifname_and_no_netdev(
+        self, mock_run: MagicMock, mocker: MockerFixture
+    ) -> None:
+        """A link missing both netdev and ifname is skipped after map lookup."""
+        mock_run.return_value.stdout = json.dumps([self._rdma_link(ifname=None, netdev=None)])
+        mocker.patch("lustre_ops.lnet_detection._ipoib_netdev_map", return_value={})
+
+        assert lnet_detection._rdma_interfaces() == []
+
+    def test_skips_link_with_no_matching_ipoib_netdev(
+        self, mock_run: MagicMock, mocker: MockerFixture
+    ) -> None:
+        """A link whose ifname has no IPoIB netdev mapping is skipped."""
+        mock_run.return_value.stdout = json.dumps([self._rdma_link("mlx5_0", netdev=None)])
+        mocker.patch("lustre_ops.lnet_detection._ipoib_netdev_map", return_value={})
+
+        assert lnet_detection._rdma_interfaces() == []
+
+    def test_rdma_not_found(self, mock_run: MagicMock) -> None:
+        """FileNotFoundError (rdma not installed) raises LNetError."""
+        mock_run.side_effect = FileNotFoundError(1, "/bad/path/to/rdma")
+
+        with pytest.raises(LNetError) as excinfo:
+            lnet_detection._rdma_interfaces()
+        assert isinstance(excinfo.value.__cause__, FileNotFoundError)
+
+    def test_rdma_command_fails(self, mock_run: MagicMock) -> None:
+        """A non-zero exit from rdma raises LNetError."""
+        mock_run.side_effect = subprocess.CalledProcessError(1, "rdma error")
+
+        with pytest.raises(LNetError) as excinfo:
+            lnet_detection._rdma_interfaces()
+        assert isinstance(excinfo.value.__cause__, subprocess.CalledProcessError)
+
+    def test_bad_json(self, mock_run: MagicMock) -> None:
+        """Invalid JSON output raises LNetError."""
+        mock_run.return_value.stdout = "not json"
+
+        with pytest.raises(LNetError) as excinfo:
+            lnet_detection._rdma_interfaces()
+        assert isinstance(excinfo.value.__cause__, json.JSONDecodeError)
+
+
+class TestIpoibNetdevMap:
+    """_ipoib_netdev_map() tests."""
+
+    @pytest.fixture
+    def sys_class_net(self, mocker: MockerFixture, tmp_path: Path) -> Path:
+        """Return sysfs net root mocked to a temp directory."""
+        mocker.patch("lustre_ops.lnet_detection.SYS_CLASS_NET", tmp_path)
+        return tmp_path
+
+    @staticmethod
+    def _add_ipoib_netdev(root: Path, netdev: str, ib_devs: list[str]) -> None:
+        """Create a test netdev backed by the given InfiniBand device(s)."""
+        ib_path = root / netdev / "device" / "infiniband"
+        ib_path.mkdir(parents=True)
+        for dev in ib_devs:
+            (ib_path / dev).mkdir()
+
+    def test_maps_single_ib_device(self, sys_class_net: Path) -> None:
+        """A netdev backed by exactly one IB device is mapped."""
+        self._add_ipoib_netdev(sys_class_net, "ib0", ["mlx5_0"])
+
+        assert lnet_detection._ipoib_netdev_map() == {"mlx5_0": "ib0"}
+
+    def test_skips_netdev_without_ib_device(self, sys_class_net: Path) -> None:
+        """Netdevs without an infiniband device directory are skipped."""
+        (sys_class_net / "eth0").mkdir()
+
+        assert lnet_detection._ipoib_netdev_map() == {}
+
+    def test_skips_netdev_with_multiple_ib_devices(self, sys_class_net: Path) -> None:
+        """Netdevs backed by multiple IB devices are skipped with a warning."""
+        self._add_ipoib_netdev(sys_class_net, "ib0", ["mlx5_0", "mlx5_1"])
+
+        assert lnet_detection._ipoib_netdev_map() == {}
+
+    def test_empty_sysfs(self, sys_class_net: Path) -> None:
+        """No netdevs in /sys/class/net yields an empty map."""
+        assert lnet_detection._ipoib_netdev_map() == {}

--- a/internal/lustre-ops/tests/unit/test_lnet_detection.py
+++ b/internal/lustre-ops/tests/unit/test_lnet_detection.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from lustre_ops import lnet_detection
-from lustre_ops.errors import LNetError
+from lustre_ops.errors import LNetParseError, LNetQueryError
 from pytest_mock import MockerFixture
 
 
@@ -68,25 +68,22 @@ class TestDefaultRouteInterface:
         """Ip command fails."""
         mock_run.side_effect = subprocess.CalledProcessError(1, "ip")
 
-        with pytest.raises(LNetError) as excinfo:
+        with pytest.raises(LNetQueryError):
             lnet_detection._default_route_interface()
-        assert isinstance(excinfo.value.__cause__, subprocess.CalledProcessError)
 
     def test_bad_json(self, mock_run: MagicMock) -> None:
         """Ip command returns invalid JSON."""
         mock_run.return_value.stdout = "not json"
 
-        with pytest.raises(LNetError) as excinfo:
+        with pytest.raises(LNetParseError):
             lnet_detection._default_route_interface()
-        assert isinstance(excinfo.value.__cause__, json.JSONDecodeError)
 
     def test_missing_dev_key(self, mock_run: MagicMock) -> None:
         """Ip command returns JSON without 'dev' key."""
         mock_run.return_value.stdout = json.dumps([{"not_dev": "eth0"}])
 
-        with pytest.raises(LNetError) as excinfo:
+        with pytest.raises(LNetParseError):
             lnet_detection._default_route_interface()
-        assert isinstance(excinfo.value.__cause__, KeyError)
 
 
 class TestRdmaInterfaces:
@@ -194,28 +191,25 @@ class TestRdmaInterfaces:
         assert lnet_detection._rdma_interfaces() == []
 
     def test_rdma_not_found(self, mock_run: MagicMock) -> None:
-        """FileNotFoundError (rdma not installed) raises LNetError."""
+        """FileNotFoundError (rdma not installed) raises error."""
         mock_run.side_effect = FileNotFoundError(1, "/bad/path/to/rdma")
 
-        with pytest.raises(LNetError) as excinfo:
+        with pytest.raises(LNetQueryError):
             lnet_detection._rdma_interfaces()
-        assert isinstance(excinfo.value.__cause__, FileNotFoundError)
 
     def test_rdma_command_fails(self, mock_run: MagicMock) -> None:
-        """A non-zero exit from rdma raises LNetError."""
+        """A non-zero exit from rdma raises error."""
         mock_run.side_effect = subprocess.CalledProcessError(1, "rdma error")
 
-        with pytest.raises(LNetError) as excinfo:
+        with pytest.raises(LNetQueryError):
             lnet_detection._rdma_interfaces()
-        assert isinstance(excinfo.value.__cause__, subprocess.CalledProcessError)
 
     def test_bad_json(self, mock_run: MagicMock) -> None:
-        """Invalid JSON output raises LNetError."""
+        """Invalid JSON output raises error."""
         mock_run.return_value.stdout = "not json"
 
-        with pytest.raises(LNetError) as excinfo:
+        with pytest.raises(LNetParseError):
             lnet_detection._rdma_interfaces()
-        assert isinstance(excinfo.value.__cause__, json.JSONDecodeError)
 
 
 class TestIpoibNetdevMap:

--- a/internal/lustre-ops/tests/unit/test_lnet_detection.py
+++ b/internal/lustre-ops/tests/unit/test_lnet_detection.py
@@ -215,7 +215,7 @@ class TestRdmaInterfaces:
 class TestIpoibNetdevMap:
     """_ipoib_netdev_map() tests."""
 
-    @pytest.fixture
+    @pytest.fixture(scope="function")
     def sys_class_net(self, mocker: MockerFixture, tmp_path: Path) -> Path:
         """Return sysfs net root mocked to a temp directory."""
         mocker.patch("lustre_ops.lnet_detection.SYS_CLASS_NET", tmp_path)

--- a/internal/lustre-ops/tests/unit/test_ppa.py
+++ b/internal/lustre-ops/tests/unit/test_ppa.py
@@ -13,11 +13,12 @@ from lustre_ops.errors import RepositoryCodenameError, RepositoryGPGKeyError, Re
 from pytest_mock import MockerFixture
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(scope="function", autouse=True)
 def mock_os_release(mocker: MockerFixture) -> MagicMock:
     """Mock platform.freedesktop_os_release."""
-    return mocker.patch(
-        "lustre_ops.ppa.platform.freedesktop_os_release",
+    return mocker.patch.object(
+        ppa.platform,
+        "freedesktop_os_release",
         return_value={"VERSION_CODENAME": "noble"},
     )
 
@@ -27,9 +28,9 @@ class TestSetupLustreRepository:
 
     def test_success(self, mocker: MockerFixture) -> None:
         """Repository is configured and the APT index refreshed."""
-        mock_repo = mocker.patch("lustre_ops.ppa.apt.DebianRepository")
-        mock_mapping = mocker.patch("lustre_ops.ppa.apt.RepositoryMapping").return_value
-        mock_update = mocker.patch("lustre_ops.ppa.apt.update")
+        mock_repo = mocker.patch.object(ppa.apt, "DebianRepository")
+        mock_mapping = mocker.patch.object(ppa.apt, "RepositoryMapping").return_value
+        mock_update = mocker.patch.object(ppa.apt, "update")
 
         ppa.setup_lustre_repository()
 
@@ -43,14 +44,14 @@ class TestSetupLustreRepository:
     ) -> None:
         """Failure to retrieve the OS codename raises error."""
         mock_os_release.return_value = {}
-        mocker.patch("lustre_ops.ppa.apt.DebianRepository")
+        mocker.patch.object(ppa.apt, "DebianRepository")
 
         with pytest.raises(RepositoryCodenameError):
             ppa.setup_lustre_repository()
 
     def test_gpg_key_error(self, mocker: MockerFixture) -> None:
         """GPG key import failure raises error."""
-        mock_repo = mocker.patch("lustre_ops.ppa.apt.DebianRepository").return_value
+        mock_repo = mocker.patch.object(ppa.apt, "DebianRepository").return_value
         mock_repo.import_key.side_effect = apt.GPGKeyError("bad key")
 
         with pytest.raises(RepositoryGPGKeyError):
@@ -58,8 +59,8 @@ class TestSetupLustreRepository:
 
     def test_repo_add_error(self, mocker: MockerFixture) -> None:
         """Repository add/update failure raises error."""
-        mocker.patch("lustre_ops.ppa.apt.DebianRepository")
-        mock_mapping = mocker.patch("lustre_ops.ppa.apt.RepositoryMapping").return_value
+        mocker.patch.object(ppa.apt, "DebianRepository")
+        mock_mapping = mocker.patch.object(ppa.apt, "RepositoryMapping").return_value
         mock_mapping.add.side_effect = CalledProcessError(1, "apt")
 
         with pytest.raises(RepositorySyncError):
@@ -67,9 +68,9 @@ class TestSetupLustreRepository:
 
     def test_update_error(self, mocker: MockerFixture) -> None:
         """apt.update() failure raises error."""
-        mocker.patch("lustre_ops.ppa.apt.DebianRepository")
-        mocker.patch("lustre_ops.ppa.apt.RepositoryMapping")
-        mocker.patch("lustre_ops.ppa.apt.update", side_effect=CalledProcessError(1, "apt update"))
+        mocker.patch.object(ppa.apt, "DebianRepository")
+        mocker.patch.object(ppa.apt, "RepositoryMapping")
+        mocker.patch.object(ppa.apt, "update", side_effect=CalledProcessError(1, "apt update"))
 
         with pytest.raises(RepositorySyncError):
             ppa.setup_lustre_repository()

--- a/internal/lustre-ops/tests/unit/test_ppa.py
+++ b/internal/lustre-ops/tests/unit/test_ppa.py
@@ -19,7 +19,7 @@ def mock_os_release(mocker: MockerFixture) -> MagicMock:
     return mocker.patch.object(
         ppa.platform,
         "freedesktop_os_release",
-        return_value={"VERSION_CODENAME": "noble"},
+        return_value={"VERSION_CODENAME": "resolute"},
     )
 
 

--- a/internal/lustre-ops/tests/unit/test_ppa.py
+++ b/internal/lustre-ops/tests/unit/test_ppa.py
@@ -13,18 +13,19 @@ from lustre_ops.errors import RepositoryCodenameError, RepositoryGPGKeyError, Re
 from pytest_mock import MockerFixture
 
 
+@pytest.fixture(autouse=True)
+def mock_os_release(mocker: MockerFixture) -> MagicMock:
+    """Mock platform.freedesktop_os_release."""
+    return mocker.patch(
+        "lustre_ops.ppa.platform.freedesktop_os_release",
+        return_value={"VERSION_CODENAME": "noble"},
+    )
+
+
 class TestSetupLustreRepository:
     """setup_lustre_repository() tests."""
 
-    @pytest.fixture
-    def mock_os_release(self, mocker: MockerFixture) -> MagicMock:
-        """Mock platform.freedesktop_os_release."""
-        return mocker.patch(
-            "lustre_ops.ppa.platform.freedesktop_os_release",
-            return_value={"VERSION_CODENAME": "noble"},
-        )
-
-    def test_success(self, mocker: MockerFixture, mock_os_release: MagicMock) -> None:
+    def test_success(self, mocker: MockerFixture) -> None:
         """Repository is configured and the APT index refreshed."""
         mock_repo = mocker.patch("lustre_ops.ppa.apt.DebianRepository")
         mock_mapping = mocker.patch("lustre_ops.ppa.apt.RepositoryMapping").return_value
@@ -47,7 +48,7 @@ class TestSetupLustreRepository:
         with pytest.raises(RepositoryCodenameError):
             ppa.setup_lustre_repository()
 
-    def test_gpg_key_error(self, mocker: MockerFixture, mock_os_release: MagicMock) -> None:
+    def test_gpg_key_error(self, mocker: MockerFixture) -> None:
         """GPG key import failure raises error."""
         mock_repo = mocker.patch("lustre_ops.ppa.apt.DebianRepository").return_value
         mock_repo.import_key.side_effect = apt.GPGKeyError("bad key")
@@ -55,7 +56,7 @@ class TestSetupLustreRepository:
         with pytest.raises(RepositoryGPGKeyError):
             ppa.setup_lustre_repository()
 
-    def test_repo_add_error(self, mocker: MockerFixture, mock_os_release: MagicMock) -> None:
+    def test_repo_add_error(self, mocker: MockerFixture) -> None:
         """Repository add/update failure raises error."""
         mocker.patch("lustre_ops.ppa.apt.DebianRepository")
         mock_mapping = mocker.patch("lustre_ops.ppa.apt.RepositoryMapping").return_value
@@ -64,7 +65,7 @@ class TestSetupLustreRepository:
         with pytest.raises(RepositorySyncError):
             ppa.setup_lustre_repository()
 
-    def test_update_error(self, mocker: MockerFixture, mock_os_release: MagicMock) -> None:
+    def test_update_error(self, mocker: MockerFixture) -> None:
         """apt.update() failure raises error."""
         mocker.patch("lustre_ops.ppa.apt.DebianRepository")
         mocker.patch("lustre_ops.ppa.apt.RepositoryMapping")

--- a/internal/lustre-ops/tests/unit/test_ppa.py
+++ b/internal/lustre-ops/tests/unit/test_ppa.py
@@ -1,0 +1,78 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details
+
+"""Unit tests for `lustre_ops.ppa`."""
+
+from subprocess import CalledProcessError
+from unittest.mock import MagicMock
+
+import pytest
+from charmlibs import apt
+from lustre_ops import ppa
+from lustre_ops.errors import RepositoryError
+from pytest_mock import MockerFixture
+
+
+class TestSetupLustreRepository:
+    """setup_lustre_repository() tests."""
+
+    @pytest.fixture
+    def mock_os_release(self, mocker: MockerFixture) -> MagicMock:
+        """Mock platform.freedesktop_os_release."""
+        return mocker.patch(
+            "lustre_ops.ppa.platform.freedesktop_os_release",
+            return_value={"VERSION_CODENAME": "noble"},
+        )
+
+    def test_success(self, mocker: MockerFixture, mock_os_release: MagicMock) -> None:
+        """Repository is configured and the APT index refreshed."""
+        mock_repo = mocker.patch("lustre_ops.ppa.apt.DebianRepository")
+        mock_mapping = mocker.patch("lustre_ops.ppa.apt.RepositoryMapping").return_value
+        mock_update = mocker.patch("lustre_ops.ppa.apt.update")
+
+        ppa.setup_lustre_repository()
+
+        mock_repo.assert_called_once()
+        mock_repo.return_value.import_key.assert_called_once()
+        mock_mapping.add.assert_called_once_with(mock_repo.return_value)
+        mock_update.assert_called_once()
+
+    def test_missing_version_codename(
+        self, mocker: MockerFixture, mock_os_release: MagicMock
+    ) -> None:
+        """KeyError retrieving the OS codename raises RepositoryError."""
+        mock_os_release.return_value = {}
+        mocker.patch("lustre_ops.ppa.apt.DebianRepository")
+
+        with pytest.raises(RepositoryError) as excinfo:
+            ppa.setup_lustre_repository()
+        assert isinstance(excinfo.value.__cause__, KeyError)
+
+    def test_gpg_key_error(self, mocker: MockerFixture, mock_os_release: MagicMock) -> None:
+        """GPG key import failure raises RepositoryError."""
+        mock_repo = mocker.patch("lustre_ops.ppa.apt.DebianRepository").return_value
+        mock_repo.import_key.side_effect = apt.GPGKeyError("bad key")
+
+        with pytest.raises(RepositoryError) as excinfo:
+            ppa.setup_lustre_repository()
+        assert isinstance(excinfo.value.__cause__, apt.GPGKeyError)
+
+    def test_repo_add_error(self, mocker: MockerFixture, mock_os_release: MagicMock) -> None:
+        """Repository add/update failure raises RepositoryError."""
+        mocker.patch("lustre_ops.ppa.apt.DebianRepository")
+        mock_mapping = mocker.patch("lustre_ops.ppa.apt.RepositoryMapping").return_value
+        mock_mapping.add.side_effect = CalledProcessError(1, "apt")
+
+        with pytest.raises(RepositoryError) as excinfo:
+            ppa.setup_lustre_repository()
+        assert isinstance(excinfo.value.__cause__, CalledProcessError)
+
+    def test_update_error(self, mocker: MockerFixture, mock_os_release: MagicMock) -> None:
+        """apt.update() failure raises RepositoryError."""
+        mocker.patch("lustre_ops.ppa.apt.DebianRepository")
+        mocker.patch("lustre_ops.ppa.apt.RepositoryMapping")
+        mocker.patch("lustre_ops.ppa.apt.update", side_effect=CalledProcessError(1, "apt update"))
+
+        with pytest.raises(RepositoryError) as excinfo:
+            ppa.setup_lustre_repository()
+        assert isinstance(excinfo.value.__cause__, CalledProcessError)

--- a/internal/lustre-ops/tests/unit/test_ppa.py
+++ b/internal/lustre-ops/tests/unit/test_ppa.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock
 import pytest
 from charmlibs import apt
 from lustre_ops import ppa
-from lustre_ops.errors import RepositoryError
+from lustre_ops.errors import RepositoryCodenameError, RepositoryGPGKeyError, RepositorySyncError
 from pytest_mock import MockerFixture
 
 
@@ -40,39 +40,35 @@ class TestSetupLustreRepository:
     def test_missing_version_codename(
         self, mocker: MockerFixture, mock_os_release: MagicMock
     ) -> None:
-        """KeyError retrieving the OS codename raises RepositoryError."""
+        """Failure to retrieve the OS codename raises error."""
         mock_os_release.return_value = {}
         mocker.patch("lustre_ops.ppa.apt.DebianRepository")
 
-        with pytest.raises(RepositoryError) as excinfo:
+        with pytest.raises(RepositoryCodenameError):
             ppa.setup_lustre_repository()
-        assert isinstance(excinfo.value.__cause__, KeyError)
 
     def test_gpg_key_error(self, mocker: MockerFixture, mock_os_release: MagicMock) -> None:
-        """GPG key import failure raises RepositoryError."""
+        """GPG key import failure raises error."""
         mock_repo = mocker.patch("lustre_ops.ppa.apt.DebianRepository").return_value
         mock_repo.import_key.side_effect = apt.GPGKeyError("bad key")
 
-        with pytest.raises(RepositoryError) as excinfo:
+        with pytest.raises(RepositoryGPGKeyError):
             ppa.setup_lustre_repository()
-        assert isinstance(excinfo.value.__cause__, apt.GPGKeyError)
 
     def test_repo_add_error(self, mocker: MockerFixture, mock_os_release: MagicMock) -> None:
-        """Repository add/update failure raises RepositoryError."""
+        """Repository add/update failure raises error."""
         mocker.patch("lustre_ops.ppa.apt.DebianRepository")
         mock_mapping = mocker.patch("lustre_ops.ppa.apt.RepositoryMapping").return_value
         mock_mapping.add.side_effect = CalledProcessError(1, "apt")
 
-        with pytest.raises(RepositoryError) as excinfo:
+        with pytest.raises(RepositorySyncError):
             ppa.setup_lustre_repository()
-        assert isinstance(excinfo.value.__cause__, CalledProcessError)
 
     def test_update_error(self, mocker: MockerFixture, mock_os_release: MagicMock) -> None:
-        """apt.update() failure raises RepositoryError."""
+        """apt.update() failure raises error."""
         mocker.patch("lustre_ops.ppa.apt.DebianRepository")
         mocker.patch("lustre_ops.ppa.apt.RepositoryMapping")
         mocker.patch("lustre_ops.ppa.apt.update", side_effect=CalledProcessError(1, "apt update"))
 
-        with pytest.raises(RepositoryError) as excinfo:
+        with pytest.raises(RepositorySyncError):
             ppa.setup_lustre_repository()
-        assert isinstance(excinfo.value.__cause__, CalledProcessError)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "charmlibs-apt ~= 1.0",
     "charmed-hpc-libs[ops] ~= 0.1",
     "pydantic>=2",
+    "lustre-ops",
 ]
 
 [project.optional-dependencies]
@@ -32,7 +33,10 @@ dev = [
 ]
 
 [tool.uv.workspace]
-members = ["charms/*"]
+members = ["charms/*", "internal/*"]
+
+[tool.uv.sources]
+lustre-ops = { workspace = true }
 
 [tool.repository]
 
@@ -41,7 +45,8 @@ members = ["charms/*"]
 branch = true
 include = [
     "_build/**/src/*",
-    "_build/filesystem-client/lib/charms/filesystem_client/*"
+    "_build/filesystem-client/lib/charms/filesystem_client/*",
+    "internal/**/src/*",
 ]
 omit = [
     "_build/libs/*"

--- a/repository.py
+++ b/repository.py
@@ -225,7 +225,7 @@ class Repository:
             self.public_packages = [
                 pkg
                 for path in PUBLIC_PKGS_PATH.iterdir()
-                if (pkg := load_package(path) is not None)
+                if (pkg := load_package(path)) is not None
             ]
         except FileNotFoundError:
             # `PUBLIC_PKGS_PATH` does not exist, so we don't have any private packages.

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,7 @@ members = [
     "cephfs-server-proxy",
     "filesystem-client",
     "filesystems",
+    "lustre-ops",
     "lustre-server",
     "lustre-server-proxy",
     "nfs-server-proxy",
@@ -125,6 +126,7 @@ source = { virtual = "charms/filesystem-client" }
 dependencies = [
     { name = "charmed-hpc-libs", extra = ["ops"] },
     { name = "charmlibs-apt" },
+    { name = "lustre-ops" },
     { name = "ops" },
 ]
 
@@ -132,6 +134,7 @@ dependencies = [
 requires-dist = [
     { name = "charmed-hpc-libs", extras = ["ops"] },
     { name = "charmlibs-apt" },
+    { name = "lustre-ops", editable = "internal/lustre-ops" },
     { name = "ops" },
 ]
 
@@ -142,6 +145,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "charmed-hpc-libs", extra = ["ops"] },
     { name = "charmlibs-apt" },
+    { name = "lustre-ops" },
     { name = "ops" },
     { name = "pydantic" },
 ]
@@ -168,6 +172,7 @@ requires-dist = [
     { name = "codespell", marker = "extra == 'dev'" },
     { name = "coverage", extras = ["toml"], marker = "extra == 'dev'" },
     { name = "jubilant", marker = "extra == 'dev'" },
+    { name = "lustre-ops", editable = "internal/lustre-ops" },
     { name = "ops", specifier = "~=3.0" },
     { name = "ops", extras = ["testing"], marker = "extra == 'dev'" },
     { name = "pydantic", specifier = ">=2" },
@@ -203,12 +208,30 @@ wheels = [
 ]
 
 [[package]]
+name = "lustre-ops"
+version = "0.0.1"
+source = { editable = "internal/lustre-ops" }
+dependencies = [
+    { name = "charmlibs-apt" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "charmlibs-apt" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+]
+
+[[package]]
 name = "lustre-server"
 version = "0.0.1"
 source = { virtual = "charms/lustre-server" }
 dependencies = [
     { name = "charmed-hpc-libs", extra = ["ops"] },
     { name = "charmlibs-apt" },
+    { name = "lustre-ops" },
     { name = "ops" },
     { name = "pydantic" },
 ]
@@ -217,6 +240,7 @@ dependencies = [
 requires-dist = [
     { name = "charmed-hpc-libs", extras = ["ops"] },
     { name = "charmlibs-apt" },
+    { name = "lustre-ops", editable = "internal/lustre-ops" },
     { name = "ops" },
     { name = "pydantic" },
 ]


### PR DESCRIPTION
# Pre-submission checklist

 * [X] I read and followed the CONTRIBUTING guidelines.
 * [X] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

Duplicate LNet initialization code from the filesystem-client and lustre-server charms has been consolidated in a lustre-ops package:
* Following the convention set by slurm-ops in our Slurm charms, the new package is located in an "internal" subdirectory.
* Relevant pyproject.toml changes are made to reference the package.
* The package handles LNet initialization with a shared `lnet.init()` method.
* Setup of the PPA containing Lustre packages are also moved here.

Support for custom LNet configuration is added, as well as autodetection and set up of ethernet and RDMA devices:
* The MGS unit now supports publishing multiple NIDs to the peer relation data for OSS units to reference - `mgs_nid: str` is now `mgs_nids: list`.
* A `lnet-networks` config option is added to both filesystem-client and lustre-server to allow users to specify NID and associated interfaces. Example: `juju deploy lustre-server --config lnet-networks="tcp=eth0; o2ib0=ib0,ib1"`
* If `lnet-networks` is not specified, autodetection is performed.
  * A `@tcp` NID is set up with the interface for the default route (unchanged from current behavior)
  * A `@o2ib` NID is set up in multi-rail with all RDMA devices detected via `rdma show link` and scanning `/sys/class/net/*/device/infiniband`

Changes requiring particular review attention:
* The `lnet-networks` config uses a minimal, flat string format to simplify CLI deployment. Open to moving to a structured format (YAML/JSON) if preferred.
* Autodetection configures both TCP and InfiniBand in LNet by default. Open to feedback on whether we should exclusively configure InfiniBand if any IB interfaces are found.

A minor bug fix for repository.py is also included:
* `if (pkg := load_package(path) is not None)` is changed to `if (pkg := load_package(path)) is not None` as operator precedence was resulting in `pkg` being erroneously assigned `True` or `False`.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

This is necessary to address the code duplication between the filesystem-client and lustre-server charms, and to enable support 

## Docs

* [X] I have created a pull request to add or update relevant documentation in [canonical/charmed-hpc-docs](https://github.com/canonical/charmed-hpc-docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than canonical/charmed-hpc-docs, please note the location here.)

Or:

* [ ] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

https://github.com/canonical/charmed-hpc-docs/pull/155 is in draft status as the Lustre server charm is still experimental. The PR will be taken out of draft and merged in conjunction with the first release of the charm at a later date.