### PR TITLE
fix: allow tagging commits within the publish action

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -28,6 +28,8 @@ jobs:
     needs:
       - ci-tests
     runs-on: ubuntu-26.04
+    permissions:
+      contents: write
     strategy:
       fail-fast: true
       matrix:


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

## Summary of changes

Fixes the CI error we were having while trying to publish by giving write permissions to the Github token.

## Docs

* [x] I confirm that this pull request requires no changes or additions to documentation.

Internal fix.
