### PR TITLE
docs: add documentation and contact links to charmcraft.yaml

### DIFF
--- a/charms/cephfs-server-proxy/charmcraft.yaml
+++ b/charms/cephfs-server-proxy/charmcraft.yaml
@@ -1,19 +1,34 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2024-2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 name: cephfs-server-proxy
 type: charm
 title: CephFS Proxy
-summary: Charmed Ceph FS server for non-charmed Ceph storage appliances.
+summary: Charmed operator for proxying access to an uncharmed CephFS filesystem.
 description: |
-  Charmed Ceph FS server for non-charmed Ceph storage appliances.
+  As part of Charmed HPC, this charm deploys and manages a CephFS server proxy
+  that exposes non-charmed Ceph storage appliances as Charmed filesystems. It
+  bridges external Ceph clusters by providing authentication and connection
+  details, enabling Charmed HPC workloads to mount non-charmed CephFS shares.
 
-  Enable CephFS Client charms to mount non-charmed Ceph shares.
+  This charm integrates with the filesystem-client charm to provide mount
+  information for CephFS shares to workload charms.
+
+  See the following how-to in Charmed HPC's documentation for more information about
+  how the cephfs-server-proxy charm is used in Charmed HPC:
+
+  - [How to deploy a shared filesystem](https://ubuntu.com/hpc/docs/latest/howto/deploy/deploy-shared-filesystem/#how-to-deploy-a-shared-filesystem)
+
+  For more information about Charmed HPC, view the
+  [full documentation](https://ubuntu.com/hpc/docs/latest).
 links:
+  contact: https://matrix.to/#/#hpc:ubuntu.com
+  documentation: https://ubuntu.com/hpc/docs/latest
+  website: https://ubuntu.com/hpc
   source:
-  - https://github.com/canonical/filesystem-charms
+    - https://github.com/canonical/filesystem-charms
   issues:
-  - https://github.com/canonical/filesystem-charms/issues
+    - https://github.com/canonical/filesystem-charms/issues
 
 platforms:
   ubuntu@26.04:amd64:

--- a/charms/filesystem-client/charmcraft.yaml
+++ b/charms/filesystem-client/charmcraft.yaml
@@ -1,18 +1,36 @@
-# Copyright 2024-2025 Canonical Ltd.
+# Copyright 2024-2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 name: filesystem-client
-
 type: charm
-
 title: Filesystem Client
-
-summary: Mount filesystems on machine charms.
-
+summary: Charmed operator for mounting filesystems on machine charms.
 description: |
-  Mount filesystems on machine charms.
+  As part of Charmed HPC, this charm deploys and manages the filesystem client
+  responsible for mounting shared filesystems on machine charms. It handles the
+  mount lifecycle and exposes mount information to workload charms, providing
+  applications with access to exported filesystems.
 
-  Enables access to exported filesystems.
+  This charm integrates with the cephfs-server-proxy, lustre-server,
+  lustre-server-proxy, and nfs-server-proxy charms to mount shared filesystems,
+  and with workload charms to expose those mounts in their machines.
+
+  See the following how-to in Charmed HPC's documentation for more information about
+  how the filesystem-client charm is used in Charmed HPC:
+
+  - [How to deploy a shared filesystem](https://ubuntu.com/hpc/docs/latest/howto/deploy/deploy-shared-filesystem/#how-to-deploy-a-shared-filesystem)
+
+  For more information about Charmed HPC, view the
+  [full documentation](https://ubuntu.com/hpc/docs/latest).
+
+links:
+  contact: https://matrix.to/#/#hpc:ubuntu.com
+  documentation: https://ubuntu.com/hpc/docs/latest
+  website: https://ubuntu.com/hpc
+  source:
+    - https://github.com/canonical/filesystem-charms
+  issues:
+    - https://github.com/canonical/filesystem-charms/issues
 
 platforms:
   ubuntu@26.04:amd64:

--- a/charms/lustre-server-proxy/charmcraft.yaml
+++ b/charms/lustre-server-proxy/charmcraft.yaml
@@ -1,19 +1,34 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2025-2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 name: lustre-server-proxy
 type: charm
 title: Lustre Server Proxy
-summary: Charmed Lustre server for non-charmed Lustre storage appliances.
+summary: Charmed operator for proxying access to an uncharmed Lustre filesystem.
 description: |
-  Charmed Lustre server for non-charmed Lustre storage appliances.
+  As part of Charmed HPC, this charm deploys and manages a Lustre server proxy
+  that exposes non-charmed Lustre storage appliances as Charmed filesystems. It
+  bridges external Lustre clusters by providing connection details and filesystem
+  information, enabling Charmed HPC workloads to mount non-charmed Lustre shares.
 
-  Enable Lustre Client charms to mount non-charmed Lustre shares.
+  This charm integrates with the filesystem-client charm to provide mount
+  information for Lustre shares to workload charms.
+
+  See the following how-to in Charmed HPC's documentation for more information about
+  how the lustre-server-proxy charm is used in Charmed HPC:
+
+  - [How to deploy a shared filesystem](https://ubuntu.com/hpc/docs/latest/howto/deploy/deploy-shared-filesystem/#how-to-deploy-a-shared-filesystem)
+
+  For more information about Charmed HPC, view the
+  [full documentation](https://ubuntu.com/hpc/docs/latest).
 links:
+  contact: https://matrix.to/#/#hpc:ubuntu.com
+  documentation: https://ubuntu.com/hpc/docs/latest
+  website: https://ubuntu.com/hpc
   source:
-  - https://github.com/canonical/filesystem-charms
+    - https://github.com/canonical/filesystem-charms
   issues:
-  - https://github.com/canonical/filesystem-charms/issues
+    - https://github.com/canonical/filesystem-charms/issues
 
 platforms:
   ubuntu@26.04:amd64:

--- a/charms/nfs-server-proxy/charmcraft.yaml
+++ b/charms/nfs-server-proxy/charmcraft.yaml
@@ -1,19 +1,34 @@
-# Copyright 2023 Canonical Ltd.
+# Copyright 2023-2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 name: nfs-server-proxy
 type: charm
 title: NFS Server Proxy
-summary: Charmed NFS server for non-charmed NFS storage appliances.
+summary: Charmed operator for proxying access to an uncharmed NFS filesystem.
 description: |
-  Charmed NFS server for non-charmed NFS storage appliances.
+  As part of Charmed HPC, this charm deploys and manages an NFS server proxy
+  that exposes non-charmed NFS storage appliances as Charmed filesystems. It
+  bridges external NFS servers by providing connection details and export
+  information, enabling Charmed HPC workloads to mount non-charmed NFS shares.
 
-  Enable NFS Client charms to mount non-charmed NFS shares.
+  This charm integrates with the filesystem-client charm to provide mount
+  information for NFS shares to workload charms.
+
+  See the following how-to in Charmed HPC's documentation for more information about
+  how the nfs-server-proxy charm is used in Charmed HPC:
+
+  - [How to deploy a shared filesystem](https://ubuntu.com/hpc/docs/latest/howto/deploy/deploy-shared-filesystem/#how-to-deploy-a-shared-filesystem)
+
+  For more information about Charmed HPC, view the
+  [full documentation](https://ubuntu.com/hpc/docs/latest).
 links:
+  contact: https://matrix.to/#/#hpc:ubuntu.com
+  documentation: https://ubuntu.com/hpc/docs/latest
+  website: https://ubuntu.com/hpc
   source:
-  - https://github.com/canonical/filesystem-charms
+    - https://github.com/canonical/filesystem-charms
   issues:
-  - https://github.com/canonical/filesystem-charms/issues
+    - https://github.com/canonical/filesystem-charms/issues
 
 platforms:
   ubuntu@26.04:amd64:


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

## Summary of changes

This PR adds the required documentation and contact links on each public charm's charmcraft.yaml file.
A small detail is that the lustre charms don't really have how-to docs in place, so these new docs assume we're adding that in the future. We might have to refresh these links after https://github.com/canonical/charmed-hpc-docs/pull/155 gets merged.

## Docs

* [x] I have created a pull request to add or update relevant documentation in [canonical/charmed-hpc-docs](https://github.com/canonical/charmed-hpc-docs) or another documentation location.

This updates public docs.