### PR TITLE
chore: enable publishing lustre-server to charmhub

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -38,6 +38,7 @@ jobs:
           - cephfs-server-proxy
           - nfs-server-proxy
           - lustre-server-proxy
+          - lustre-server
     steps:
       - name: Checkout
         uses: actions/checkout@v7


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

## Summary of changes

~Depends on #42.~

Enables publishing the lustre-server charm to Charmhub.


## Docs

* [x] I confirm that this pull request requires no changes or additions to documentation.

The required documentation update for Charmhub has already been addressed by #42, which is why this is blocked on merging that PR.