### PR TITLE
feat: add Terraform module for lustre-server

### DIFF
--- a/charms/lustre-server/terraform/README.md
+++ b/charms/lustre-server/terraform/README.md
@@ -1,0 +1,60 @@
+# Terraform module for lustre-server
+
+This is a Terraform module facilitating the deployment of the lustre-server charm using
+the [Juju Terraform provider](https://github.com/juju/terraform-provider-juju).
+For more information, refer to the
+[documentation](https://registry.terraform.io/providers/juju/juju/latest/docs)
+for the Juju Terraform provider.
+
+## Requirements
+
+- Terraform >= 1.0
+- Juju Terraform provider >= 1.0.0, < 2.0.0
+- An existing Juju model
+
+## API
+
+### Inputs
+
+| Name          | Type        | Description                                                        | Default           | Required |
+|---------------|-------------|--------------------------------------------------------------------|-------------------|:--------:|
+| `app_name`    | string      | Name for the deployed application                                  | `"lustre-server"` |          |
+| `base`        | string      | Operating system base for the charm (e.g. ubuntu@26.04)            | `null`            |          |
+| `channel`     | string      | Charm channel to deploy from                                       | `"latest/edge"`   |          |
+| `config`      | map(string) | Map of charm configuration options                                 | `{}`              |          |
+| `constraints` | string      | Constraints string for the charm deployment                        | `null`            |          |
+| `machines`    | set(string) | List of machine resources to deploy the charm on                   | `[]`              |          |
+| `model_uuid`  | string      | UUID of the Juju model to deploy the charm into                    |                   |    Y     |
+| `revision`    | number      | Charm revision to deploy. Null deploys the latest on given channel | `null`            |          |
+| `units`       | number      | Number of application units to deploy                              | `1`               |          |
+
+### Outputs
+
+| Name          | Description                              |
+|---------------|------------------------------------------|
+| `application` | The deployed `juju_application` resource |
+| `provides`    | Map of `provides` endpoint names         |
+
+The `provides` output exposes the following endpoint names:
+
+| Key          | Endpoint name |
+|--------------|---------------|
+| `filesystem` | `filesystem`  |
+
+## Usage
+
+Ensure that Terraform is aware of the Juju model dependency of the charm module.
+
+```hcl
+module "lustre-server" {
+  source     = "git::https://github.com/canonical/filesystem-charms//charms/lustre-server/terraform"
+  model_uuid = juju_model.my_model.uuid
+}
+```
+
+To deploy this module with its required dependency, you can run the following
+command:
+
+```shell
+terraform apply -var="model_uuid=<MODEL_UUID>" -auto-approve
+```

--- a/charms/lustre-server/terraform/main.tf
+++ b/charms/lustre-server/terraform/main.tf
@@ -1,0 +1,30 @@
+# Copyright 2026 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "juju_application" "lustre-server" {
+  name       = var.app_name
+  model_uuid = var.model_uuid
+
+  charm {
+    name     = "lustre-server"
+    base     = var.base
+    channel  = var.channel
+    revision = var.revision
+  }
+
+  config      = var.config
+  constraints = var.constraints
+  machines    = var.machines
+  units       = var.units
+}

--- a/charms/lustre-server/terraform/outputs.tf
+++ b/charms/lustre-server/terraform/outputs.tf
@@ -1,0 +1,23 @@
+# Copyright 2026 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "application" {
+  value = juju_application.lustre-server
+}
+
+output "provides" {
+  value = {
+    filesystem = "filesystem"
+  }
+}

--- a/charms/lustre-server/terraform/providers.tf
+++ b/charms/lustre-server/terraform/providers.tf
@@ -1,0 +1,15 @@
+# Copyright 2026 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+provider "juju" {}

--- a/charms/lustre-server/terraform/terraform.tf
+++ b/charms/lustre-server/terraform/terraform.tf
@@ -1,0 +1,24 @@
+# Copyright 2026 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 1.0"
+    }
+  }
+}

--- a/charms/lustre-server/terraform/variables.tf
+++ b/charms/lustre-server/terraform/variables.tf
@@ -1,0 +1,68 @@
+# Copyright 2026 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "app_name" {
+  description = "Name for the deployed application"
+  type        = string
+  default     = "lustre-server"
+}
+
+variable "base" {
+  description = "Operating system base for the charm (for example, ubuntu@26.04)"
+  type        = string
+  default     = null
+}
+
+variable "channel" {
+  description = "Charm channel to deploy from"
+  type        = string
+  default     = "latest/edge"
+}
+
+variable "config" {
+  description = "Map of charm configuration options"
+  type        = map(string)
+  default     = {}
+}
+
+variable "constraints" {
+  description = "Constraints string for the charm deployment"
+  type        = string
+  default     = null
+}
+
+variable "machines" {
+  description = "List of machine resources to deploy the charm on"
+  type        = set(string)
+  default     = []
+}
+
+variable "model_uuid" {
+  description = "UUID of the Juju model to deploy the charm into"
+  type        = string
+  nullable    = false
+}
+
+variable "revision" {
+  description = "Charm revision to deploy. Null deploys the latest on the given channel"
+  type        = number
+  nullable    = true
+  default     = null
+}
+
+variable "units" {
+  description = "Number of application units to deploy"
+  type        = number
+  default     = 1
+}


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

## Summary of changes

Adds a Terraform module for deploying the Lustre server, facilitating the setup of a Lustre cluster with Terraform.

## Docs

* [x] I have created a pull request to add or update relevant documentation in [canonical/charmed-hpc-docs](https://github.com/canonical/charmed-hpc-docs) or another documentation location.

A README has been added with all the information on how to use the Terraform module.
