### PR TITLE
fix: allow deploying terraform modules with default values

### DIFF
--- a/charms/cephfs-server-proxy/terraform/README.md
+++ b/charms/cephfs-server-proxy/terraform/README.md
@@ -23,7 +23,7 @@ for the Juju Terraform provider.
 | `channel`     | string      | Charm channel to deploy from                                       | `"latest/edge"`         |          |
 | `config`      | map(string) | Map of charm configuration options                                 | `{}`                    |          |
 | `constraints` | string      | Constraints string for the charm deployment                        | `null`                  |          |
-| `machines`    | set(string) | List of machine resources to deploy the charm on                   | `[]`                    |          |
+| `machines`    | set(string) | List of machine resources to deploy the charm on                   | `null`                  |          |
 | `model_uuid`  | string      | UUID of the Juju model to deploy the charm into                    |                         |    Y     |
 | `revision`    | number      | Charm revision to deploy. Null deploys the latest on given channel | `null`                  |          |
 | `units`       | number      | Number of application units to deploy                              | `1`                     |          |

--- a/charms/cephfs-server-proxy/terraform/variables.tf
+++ b/charms/cephfs-server-proxy/terraform/variables.tf
@@ -45,7 +45,7 @@ variable "constraints" {
 variable "machines" {
   description = "List of machine resources to deploy the charm on"
   type        = set(string)
-  default     = []
+  default     = null
 }
 
 variable "model_uuid" {

--- a/charms/lustre-server-proxy/terraform/README.md
+++ b/charms/lustre-server-proxy/terraform/README.md
@@ -23,7 +23,7 @@ for the Juju Terraform provider.
 | `channel`     | string      | Charm channel to deploy from                                       | `"latest/edge"`         |          |
 | `config`      | map(string) | Map of charm configuration options                                 | `{}`                    |          |
 | `constraints` | string      | Constraints string for the charm deployment                        | `null`                  |          |
-| `machines`    | set(string) | List of machine resources to deploy the charm on                   | `[]`                    |          |
+| `machines`    | set(string) | List of machine resources to deploy the charm on                   | `null`                  |          |
 | `model_uuid`  | string      | UUID of the Juju model to deploy the charm into                    |                         |    Y     |
 | `revision`    | number      | Charm revision to deploy. Null deploys the latest on given channel | `null`                  |          |
 | `units`       | number      | Number of application units to deploy                              | `1`                     |          |

--- a/charms/lustre-server-proxy/terraform/variables.tf
+++ b/charms/lustre-server-proxy/terraform/variables.tf
@@ -45,7 +45,7 @@ variable "constraints" {
 variable "machines" {
   description = "List of machine resources to deploy the charm on"
   type        = set(string)
-  default     = []
+  default     = null
 }
 
 variable "model_uuid" {

--- a/charms/lustre-server/terraform/README.md
+++ b/charms/lustre-server/terraform/README.md
@@ -23,7 +23,7 @@ for the Juju Terraform provider.
 | `channel`     | string      | Charm channel to deploy from                                       | `"latest/edge"`   |          |
 | `config`      | map(string) | Map of charm configuration options                                 | `{}`              |          |
 | `constraints` | string      | Constraints string for the charm deployment                        | `null`            |          |
-| `machines`    | set(string) | List of machine resources to deploy the charm on                   | `[]`              |          |
+| `machines`    | set(string) | List of machine resources to deploy the charm on                   | `null`            |          |
 | `model_uuid`  | string      | UUID of the Juju model to deploy the charm into                    |                   |    Y     |
 | `revision`    | number      | Charm revision to deploy. Null deploys the latest on given channel | `null`            |          |
 | `units`       | number      | Number of application units to deploy                              | `1`               |          |

--- a/charms/lustre-server/terraform/variables.tf
+++ b/charms/lustre-server/terraform/variables.tf
@@ -45,7 +45,7 @@ variable "constraints" {
 variable "machines" {
   description = "List of machine resources to deploy the charm on"
   type        = set(string)
-  default     = []
+  default     = null
 }
 
 variable "model_uuid" {

--- a/charms/nfs-server-proxy/terraform/README.md
+++ b/charms/nfs-server-proxy/terraform/README.md
@@ -23,7 +23,7 @@ for the Juju Terraform provider.
 | `channel`     | string      | Charm channel to deploy from                                       | `"latest/edge"`      |          |
 | `config`      | map(string) | Map of charm configuration options                                 | `{}`                 |          |
 | `constraints` | string      | Constraints string for the charm deployment                        | `null`               |          |
-| `machines`    | set(string) | List of machine resources to deploy the charm on                   | `[]`                 |          |
+| `machines`    | set(string) | List of machine resources to deploy the charm on                   | `null`               |          |
 | `model_uuid`  | string      | UUID of the Juju model to deploy the charm into                    |                      |    Y     |
 | `revision`    | number      | Charm revision to deploy. Null deploys the latest on given channel | `null`               |          |
 | `units`       | number      | Number of application units to deploy                              | `1`                  |          |

--- a/charms/nfs-server-proxy/terraform/variables.tf
+++ b/charms/nfs-server-proxy/terraform/variables.tf
@@ -45,7 +45,7 @@ variable "constraints" {
 variable "machines" {
   description = "List of machine resources to deploy the charm on"
   type        = set(string)
-  default     = []
+  default     = null
 }
 
 variable "model_uuid" {


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the CONTRIBUTING guidelines.
 * [x] I have ensured that lint, typecheck, and unit tests complete successfully.

## Summary of changes

Fixes a bug in our Terraform modules where the Terraform Juju provider would reject specifying both the machines and the units fields.

## Docs

* [x] I have created a pull request to add or update relevant documentation in [canonical/charmed-hpc-docs](https://github.com/canonical/charmed-hpc-docs) or another documentation location.

README was updated to reflect the new default
