### PR TITLE
 refactor(lustre-ops): use empty dictionary over None for LNet spec 

### DIFF
--- a/charms/filesystem-client/src/utils/constants.py
+++ b/charms/filesystem-client/src/utils/constants.py
@@ -4,4 +4,5 @@ BASE_PACKAGES = ("ceph-common", "nfs-common", "autofs")
 LUSTRE_PACKAGES = (
     "lustre-client-utils",
     "lustre-client-modules-dkms",
+    "rdma-core",
 )

--- a/charms/filesystem-client/src/utils/manager.py
+++ b/charms/filesystem-client/src/utils/manager.py
@@ -116,7 +116,7 @@ class MountsManager:
         self._master_file = pathlib.Path(f"/etc/auto.master.d/{unit_id}.autofs")
         self._autofs_file = pathlib.Path(f"/etc/auto.{unit_id}")
         self.enable_lustre = False
-        self.lnet_networks: dict[str, list[str]] | None = None
+        self.lnet_networks: dict[str, list[str]] = {}
 
     def _packages(self) -> list[apt.DebianPackage]:
         """List of packages required by the client."""

--- a/charms/filesystem-client/tests/unit/test_charm.py
+++ b/charms/filesystem-client/tests/unit/test_charm.py
@@ -102,9 +102,7 @@ def test_enable_lustre_sets_manager_flag(
     )
 
 
-def test_lnet_networks_config_parsed(
-    ctx: testing.Context, mock_mounts_manager: MagicMock
-) -> None:
+def test_lnet_networks_config_parsed(ctx: testing.Context, mock_mounts_manager: MagicMock) -> None:
     """The lnet-networks config is parsed before being passed to the manager."""
     state_in = testing.State(
         config={

--- a/charms/lustre-server/src/constants.py
+++ b/charms/lustre-server/src/constants.py
@@ -16,7 +16,12 @@ LUSTRE_OST_DATASET_PREFIX = "ost"
 LUSTRE_OST_PARENT_DIRECTORY = "/mnt"
 
 # zfsutils-linux is needed but is not an explicit dependency of the Lustre debs.
-LUSTRE_PACKAGES = ["lustre-server-modules-dkms", "lustre-server-utils", "zfsutils-linux"]
+LUSTRE_PACKAGES = [
+    "lustre-server-modules-dkms",
+    "lustre-server-utils",
+    "zfsutils-linux",
+    "rdma-core",
+]
 
 MKFS_LUSTRE_EXECUTABLE = "/usr/sbin/mkfs.lustre"
 MOUNT_EXECUTABLE = "/usr/bin/mount"

--- a/charms/lustre-server/tests/unit/test_charm.py
+++ b/charms/lustre-server/tests/unit/test_charm.py
@@ -80,10 +80,10 @@ class TestCharmInstall:
         mock_apt: MagicMock,
         mock_lnet_init: MagicMock,
     ) -> None:
-        """An empty lnet-networks config triggers auto-detection (networks=None)."""
+        """An empty lnet-networks config triggers auto-detection."""
         ctx.run(ctx.on.install(), testing.State())
 
-        mock_lnet_init.assert_called_once_with(networks=None)
+        mock_lnet_init.assert_called_once_with(networks={})
 
     def test_repo_setup_fails(
         self,

--- a/internal/lustre-ops/src/lustre_ops/lnet.py
+++ b/internal/lustre-ops/src/lustre_ops/lnet.py
@@ -51,10 +51,10 @@ class _NetShowOutput(BaseModel):
     net: list[_Net] | None = None
 
 
-def init(networks: dict[str, list[str]] | None = None) -> None:
+def init(networks: dict[str, list[str]] = {}) -> None:
     """Initialize LNet on this unit. Idempotent.
 
-    When ``networks`` is ``None``, LNet networks are auto-configured based on available interfaces
+    When ``networks`` is empty, LNet networks are auto-configured based on available interfaces
     on the host: a ``tcp`` network is configured on the default-route interface and an ``o2ib``
     network is configured on all detected RDMA netdevs.
 
@@ -69,7 +69,7 @@ def init(networks: dict[str, list[str]] | None = None) -> None:
         LNetAutodetectError: If auto-detection finds no usable network interfaces.
         LNetError: If any other LNet operation fails.
     """
-    if networks is None:
+    if not networks:
         networks = detect_networks()
         _logger.info("LNet networks determined by auto-detection: %s", networks)
         if not networks:
@@ -99,7 +99,7 @@ def get_nids() -> list[str]:
     return [line.strip() for line in result.stdout.splitlines() if line.strip()]
 
 
-def parse_network_config(spec: str) -> dict[str, list[str]] | None:
+def parse_network_config(spec: str) -> dict[str, list[str]]:
     """Parse an operator-supplied LNet network specification string.
 
     The string is a semicolon-separated list of networks of the form:
@@ -117,15 +117,15 @@ def parse_network_config(spec: str) -> dict[str, list[str]] | None:
         spec: The specification string.
 
     Returns:
-        A mapping from LNet network name to its interfaces. `None` if an empty/whitespace-only spec
-        is provided.
+        A mapping from LNet network name to its interfaces. An empty dictionary
+        if an empty/whitespace-only spec is provided.
 
     Raises:
         LNetParseError: If the specification is malformed.
     """
     spec = spec.strip()
     if not spec:
-        return None
+        return {}
 
     networks: dict[str, list[str]] = {}
     for token in spec.split(";"):

--- a/internal/lustre-ops/tests/unit/test_lnet.py
+++ b/internal/lustre-ops/tests/unit/test_lnet.py
@@ -340,9 +340,9 @@ class TestParseNetworkConfig:
         "spec",
         [pytest.param("", id="empty_string"), pytest.param("   ", id="whitespace_only")],
     )
-    def test_empty_yields_none(self, spec: str) -> None:
-        """An empty or whitespace-only spec yields ``None``."""
-        assert lnet.parse_network_config(spec) is None
+    def test_empty_spec(self, spec: str) -> None:
+        """An empty or whitespace-only spec yields an empty dictionary."""
+        assert lnet.parse_network_config(spec) == {}
 
     @pytest.mark.parametrize(
         ("spec", "match"),


### PR DESCRIPTION
# Pre-submission checklist

 * [X] I read and followed the CONTRIBUTING guidelines.
 * [X] I have ensured that lint, typecheck, and unit tests complete successfully.

[//]: # (If you can't run the tests locally, create a draft PR to check against the CI pipeline. Once you verify that CI is passing, you can take your PR out of draft status. Please try running the tests locally first, before testing against the CI pipeline.)

## Summary of changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This addresses @jedel1043's final nit on https://github.com/canonical/filesystem-charms/pull/42:

`self.lnet_networks: dict[str, list[str]] = {}` is now used over `self.lnet_networks: dict[str, list[str]] | None = None` and related functions have been updated to use the empty dictionary over `None`.

It also adds `rdma-core` to the packages installed by the filesystem-client and lustre-server following discussion and agreement it should be included to provide a better IB experience out-of-the-box.

The change to the `test_lnet_networks_config_parsed` declaration was automatically applied by the code formatter.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

https://github.com/canonical/filesystem-charms/pull/42

## Docs

* [ ] I have created a pull request to add or update relevant documentation in [canonical/charmed-hpc-docs](https://github.com/canonical/charmed-hpc-docs) or another documentation location.

[//]: # (If documentation has been updated or added in a location other than canonical/charmed-hpc-docs, please note the location here.)

Or:

* [X] I confirm that this pull request requires no changes or additions to documentation.

[//]: # (If your PR does not require changes or additions to documentation, please write your justification here.)

No user documentation updates are required.